### PR TITLE
Add platform disconnect on stream stop and improve error logging

### DIFF
--- a/app/services/chat_gateway_client.py
+++ b/app/services/chat_gateway_client.py
@@ -42,38 +42,25 @@ class ChatGatewayClient:
         except Exception as e:
             logger.error(f"[Gateway] Failed to forward message: {e}")
 
-    async def connect_twitch(self, user_id: str) -> None:
+    async def connect_twitch(self, user_id: str, meeting_id: str = None) -> None:
         """Start Twitch IRC connection for user"""
         url = f"{self.base_url}/platforms/twitch/connect"
         headers = {"X-Internal-Auth": self.secret}
 
-        logger.info(f"[Gateway Client] Calling {url} with user_id={user_id}")
-        logger.debug(f"[Gateway Client] Headers: X-Internal-Auth={self.secret[:10]}...")
+        logger.info(
+            f"[Gateway Client] Calling {url} with user_id={user_id}, meeting_id={meeting_id}"
+        )
 
         try:
             async with httpx.AsyncClient(timeout=10, verify=False) as client:
                 response = await client.post(
                     url,
-                    params={"user_id": user_id},
+                    params={"user_id": user_id, "meeting_id": meeting_id},
                     headers=headers,
                 )
                 logger.info(f"[Gateway Client] Response status: {response.status_code}")
-                logger.info(f"[Gateway Client] Response body: {response.text}")
                 response.raise_for_status()
                 logger.info(f"[Gateway] ✅ Started Twitch for user {user_id}")
-        except httpx.ConnectError as e:
-            logger.error(f"[Gateway] ❌ Connection failed: {e}")
-            logger.error(f"[Gateway] URL attempted: {url}")
-            logger.error("[Gateway] Is the gateway running? Can the backend reach it?")
-            raise
-        except httpx.TimeoutException as e:
-            logger.error(f"[Gateway] ❌ Request timed out: {e}")
-            raise
-        except httpx.HTTPStatusError as e:
-            logger.error(
-                f"[Gateway] ❌ HTTP error {e.response.status_code}: {e.response.text}"
-            )
-            raise
         except Exception as e:
             logger.error(f"[Gateway] ❌ Failed to start Twitch: {e}")
             raise
@@ -97,18 +84,20 @@ class ChatGatewayClient:
         except Exception as e:
             logger.error(f"[Gateway] Failed to stop Twitch: {e}")
 
-    async def connect_youtube(self, user_id: str) -> None:
+    async def connect_youtube(self, user_id: str, meeting_id: str = None) -> None:
         """Start YouTube polling for user"""
         url = f"{self.base_url}/platforms/youtube/connect"
         headers = {"X-Internal-Auth": self.secret}
 
-        logger.info(f"[Gateway Client] Calling {url} with user_id={user_id}")
+        logger.info(
+            f"[Gateway Client] Calling {url} with user_id={user_id}, meeting_id={meeting_id}"
+        )
 
         try:
             async with httpx.AsyncClient(timeout=10, verify=False) as client:
                 response = await client.post(
                     url,
-                    params={"user_id": user_id},
+                    params={"user_id": user_id, "meeting_id": meeting_id},
                     headers=headers,
                 )
                 logger.info(f"[Gateway Client] Response status: {response.status_code}")


### PR DESCRIPTION
- Track platform stream type per stream in broadcaster_service
- Disconnect Twitch/YouTube when stream stops to cleanup Redis
- Ensure Redis connection registry only persists active streams