### PR TITLE
fix(events): distinguish 404 vs 403 for start/delete actions

### DIFF
--- a/app/controllers/event_controller.py
+++ b/app/controllers/event_controller.py
@@ -109,6 +109,8 @@ async def start_event(
             raise HTTPException(status_code=400, detail="Failed to start event")
     except HTTPException:
         raise
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     except ValueError as e:
         # Handle the case where the event ID is not found
         raise HTTPException(status_code=404, detail=str(e))
@@ -366,8 +368,9 @@ async def delete_event(
             user_id=UUID(str(current_user.id)),
         )
         return {"message": "Event deleted successfully"}
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     except ValueError as e:
-        # Handle the case where the event ID is not found
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/app/services/event_service.py
+++ b/app/services/event_service.py
@@ -205,12 +205,15 @@ class EventService:
                     selectinload(Event.channel),
                     selectinload(Event.creator),
                 )
-                .where(Event.id == event_id, Event.creator_id == user_id)
+                .where(Event.id == event_id)
             )
             result = await db.execute(select_stmt)
             event = result.scalars().first()
             if not event:
-                raise ValueError(f"Event with ID {event_id} does not exist or does not belong to user {user_id}.")
+                raise ValueError(f"Event with ID {event_id} not found.")
+            # Only the creator can start the event
+            if event.creator_id != user_id:
+                raise PermissionError("You don't have permission to start this event. Only the creator can start it.")
 
             if not event.meeting_created:
                 # Create the meeting in BBB
@@ -607,12 +610,15 @@ class EventService:
         Delete an event by ID.
         """
         try:
-            # Check if the event exists and belongs to the user
-            select_stmt = select(Event).where(Event.id == event_id, Event.creator_id == user_id)
+            # Check if the event exists
+            select_stmt = select(Event).where(Event.id == event_id)
             result = await db.execute(select_stmt)
             event = result.scalars().first()
             if not event:
-                raise ValueError(f"Event with ID {event_id} does not exist or does not belong to user {user_id}.")
+                raise ValueError(f"Event with ID {event_id} not found.")
+            # Check ownership separately so the caller gets a distinct signal
+            if event.creator_id != user_id:
+                raise PermissionError("You don't have permission to delete this event. Only the creator can delete it.")
 
             # Delete the event
             delete_stmt = delete(Event).where(Event.id == event_id)

--- a/tests/services/test_event_service.py
+++ b/tests/services/test_event_service.py
@@ -156,7 +156,7 @@ async def test_start_event_wrong_owner_raises(db_session: AsyncSession, test_use
     evt_in = _make_event_create("Foreign Event", "ChanF")
     created = await svc.create_event(db_session, evt_in, test_user.id)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(PermissionError):
         await svc.start_event(db_session, created.id, other.id)
 
 
@@ -350,7 +350,7 @@ async def test_delete_event_wrong_owner_raises(db_session: AsyncSession, test_us
     db_session.add(other)
     await db_session.commit()
 
-    with pytest.raises(ValueError):
+    with pytest.raises(PermissionError):
         await svc.delete_event(db_session, created.id, other.id)
 
 


### PR DESCRIPTION
## Summary

Splits the existence + ownership checks in `start_event` and `delete_event`
so non-creators (e.g. organizers) get a clear 403 instead of the misleading
combined 404 "Event with ID … does not exist or does not belong to user …".

## Why

Organizers can see events in the dashboard (the list query includes both
creator and organizer associations), but the start/delete service queries
combined `Event.id == event_id` AND `Event.creator_id == user_id` into a
single `WHERE` clause. Non-creator organizers hit the empty-result branch
and got a 404 with a confusing message, even though the event clearly
exists in their UI.

## Changes

- `app/services/event_service.py`
  - `start_event`: existence query is run first; ownership is verified
    after, raising `PermissionError` if `creator_id != user_id`.
  - `delete_event`: same split.
- `app/controllers/event_controller.py`
  - Added `except PermissionError → HTTPException(403)` for both endpoints
    (placed before the existing `ValueError → 404` handler).

## Contract change

| Action               | Before                | After                                  |
| -------------------- | --------------------- | -------------------------------------- |
| Non-existent event   | 404 (combined message)| 404 "Event with ID … not found."       |
| Existing, not owner  | 404 (combined message)| 403 "You don't have permission to …"   |
| Existing, owner      | 200                   | 200                                    |
