### PR TITLE
Feature/admin analytics dashboard

### DIFF
--- a/alembic/versions/b1c2d3e4f5a6_add_stream_sessions_table.py
+++ b/alembic/versions/b1c2d3e4f5a6_add_stream_sessions_table.py
@@ -1,0 +1,65 @@
+"""add stream_sessions table
+
+Revision ID: b1c2d3e4f5a6
+Revises: ada3c9110b40
+Create Date: 2026-05-11 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "b1c2d3e4f5a6"
+down_revision: Union[str, None] = "ada3c9110b40"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "stream_sessions",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("stream_id", sa.String(), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("platform", sa.String(), nullable=True),
+        sa.Column("started_at", sa.DateTime(), nullable=False),
+        sa.Column("ended_at", sa.DateTime(), nullable=True),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_stream_sessions_stream_id"),
+        "stream_sessions",
+        ["stream_id"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_stream_sessions_user_started",
+        "stream_sessions",
+        ["user_id", "started_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_stream_sessions_platform_started",
+        "stream_sessions",
+        ["platform", "started_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_stream_sessions_status",
+        "stream_sessions",
+        ["status"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_stream_sessions_status", table_name="stream_sessions")
+    op.drop_index("ix_stream_sessions_platform_started", table_name="stream_sessions")
+    op.drop_index("ix_stream_sessions_user_started", table_name="stream_sessions")
+    op.drop_index(op.f("ix_stream_sessions_stream_id"), table_name="stream_sessions")
+    op.drop_table("stream_sessions")

--- a/app/controllers/admin_controller.py
+++ b/app/controllers/admin_controller.py
@@ -1,0 +1,26 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config.database.session import get_db
+from app.controllers.user_controller import require_role
+from app.models.admin_schemas import AnalyticsOverview
+from app.services.admin_analytics_service import AdminAnalyticsService
+
+router = APIRouter(
+    prefix="/api/admin",
+    tags=["Admin"],
+    dependencies=[Depends(require_role("super_admin"))],
+)
+
+
+@router.get("/analytics/overview", response_model=AnalyticsOverview)
+async def get_analytics_overview(db: AsyncSession = Depends(get_db)) -> AnalyticsOverview:
+    """
+    Platform-wide snapshot metrics: users, events, streaming, revenue.
+
+    Admin-only. Returns a single payload to minimize round-trips from the
+    dashboard. Values are computed live; for caching, wrap the service call
+    in ``@cached_db`` if/when load demands it.
+    """
+    data = await AdminAnalyticsService.get_overview(db)
+    return AnalyticsOverview.model_validate(data)

--- a/app/controllers/user_controller.py
+++ b/app/controllers/user_controller.py
@@ -168,10 +168,10 @@ async def get_user_by_id(
     user_id: UUID = Path(..., title="The ID of the user to get"),
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
-    _: bool = Depends(require_any_role("admin", "moderator")),
+    _: bool = Depends(require_any_role("super_admin", "moderator")),
 ):
     """
-    Get a user by ID (Admin/Moderator only) with caching
+    Get a user by ID (Super Admin / Moderator only) with caching
     """
     logger.info(f"User {current_user.username} is requesting user {user_id}")
 
@@ -201,10 +201,10 @@ async def update_user_role(
     user_id: UUID = Path(..., title="The ID of the user to update"),
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
-    _: bool = Depends(require_role("admin")),
+    _: bool = Depends(require_role("super_admin")),
 ):
     """
-    Update a user's role (Admin only) with cache invalidation
+    Update a user's role (Super Admin only) with cache invalidation
     """
     request_id = str(uuid.uuid4())
     logger.info(f"[{request_id}] Admin {current_user.username} updating role for user {user_id} to {role_data.role}")
@@ -227,8 +227,10 @@ async def update_user_role(
                 detail="Role cannot be empty",
             )
 
-        # Add validation for allowed roles
-        allowed_roles = ["admin", "moderator"]
+        # Add validation for allowed roles.
+        # `admin` is reserved for the future organization-scoped tier; it can
+        # be assigned now even though scoping isn't wired up yet.
+        allowed_roles = ["super_admin", "admin", "moderator"]
         if new_role not in allowed_roles:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -281,10 +283,10 @@ async def invalidate_user_cache(
     user_id: UUID = Path(..., title="The ID of the user to invalidate cache for"),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),  # Properly inject the database session
-    _: bool = Depends(require_role("admin")),
+    _: bool = Depends(require_role("super_admin")),
 ):
     """
-    Manually invalidate cache for a specific user (Admin only)
+    Manually invalidate cache for a specific user (Super Admin only)
     """
     try:
         # Get user to find keycloak_id using the properly injected db session
@@ -306,10 +308,10 @@ async def invalidate_user_cache(
 @router.get("/cache/stats")
 async def get_cache_stats(
     current_user: User = Depends(get_current_user),
-    _: bool = Depends(require_role("admin")),
+    _: bool = Depends(require_role("super_admin")),
 ):
     """
-    Get cache statistics (Admin only)
+    Get cache statistics (Super Admin only)
     """
     try:
         healthy = False

--- a/app/main.py
+++ b/app/main.py
@@ -16,6 +16,7 @@ from app.config.database.session import SessionLocal
 from app.config.logger_config import get_logger
 from app.config.redis_config import cache
 from app.config.settings import get_settings
+from app.controllers.admin_controller import router as admin_router
 from app.controllers.auth_controller import router as auth_router
 from app.controllers.bbb_controller import router as bbb_router
 from app.controllers.broadcaster_controller import router as broadcaster_router
@@ -33,7 +34,14 @@ from app.controllers.user_controller import router as user_router
 from app.controllers.youtube_controller import router as youtube_router
 
 # Import models to ensure they are registered with SQLAlchemy
-from app.models import connection_model, fcm_token_model, notification_models, payment_models, user_models  # noqa: F401
+from app.models import (  # noqa: F401
+    connection_model,
+    fcm_token_model,
+    notification_models,
+    payment_models,
+    stream_session_models,
+    user_models,
+)
 from app.services.bbb_service import BBBService
 from app.services.event_reminder_service import EventReminderService
 from app.services.stream_cleanup_service import StreamCleanupService
@@ -277,3 +285,4 @@ app.include_router(bbb_router)
 app.include_router(facebook_stream_router)
 app.include_router(payment_router)
 app.include_router(notification_router)
+app.include_router(admin_router)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -4,6 +4,7 @@ from app.models.channel.channels_model import Channel
 from app.models.connection_model import Connection
 from app.models.event.event_models import Event
 from app.models.stream_models import RtmpEndpoint
+from app.models.stream_session_models import StreamSession
 from app.models.user_models import User
 
 __all__ = [
@@ -15,4 +16,5 @@ __all__ = [
     "RtmpEndpoint",
     "BbbMeeting",
     "Connection",
+    "StreamSession",
 ]

--- a/app/models/admin_schemas.py
+++ b/app/models/admin_schemas.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class RecentUser(BaseModel):
+    id: str
+    username: str
+    email: str
+    roles: str
+    created_at: datetime
+    is_active: bool
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class RecentEvent(BaseModel):
+    id: str
+    title: str
+    status: str
+    start_date: datetime
+    creator_id: str
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class RecentTransaction(BaseModel):
+    id: str
+    amount: float
+    currency: str
+    status: str
+    transaction_type: str
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class RecentStream(BaseModel):
+    id: str
+    stream_id: str
+    user_id: str
+    platform: str | None
+    status: str
+    started_at: datetime
+    ended_at: datetime | None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class UsersStats(BaseModel):
+    total: int
+    active: int
+    inactive: int
+    new_7d: int
+    new_30d: int
+    by_role: dict[str, int]
+    latest: list[RecentUser]
+
+
+class EventsStats(BaseModel):
+    total: int
+    by_status: dict[str, int]
+    created_7d: int
+    created_30d: int
+    bbb_meetings_total: int
+    bbb_meetings_30d: int
+    latest: list[RecentEvent]
+
+
+class StreamingStats(BaseModel):
+    sessions_total: int
+    sessions_24h: int
+    sessions_30d: int
+    active_now: int
+    by_platform: dict[str, int]
+    connections_by_provider: dict[str, int]
+    latest: list[RecentStream]
+
+
+class RevenueStats(BaseModel):
+    subs_by_plan: dict[str, int]
+    subs_by_status: dict[str, int]
+    active_subscriptions: int
+    revenue_30d_usd: float
+    transactions_30d_count: int
+    failed_payments_7d: int
+    latest_transactions: list[RecentTransaction]
+
+
+class AnalyticsOverview(BaseModel):
+    generated_at: datetime
+    users: UsersStats
+    events: EventsStats
+    streaming: StreamingStats
+    revenue: RevenueStats

--- a/app/models/stream_session_models.py
+++ b/app/models/stream_session_models.py
@@ -47,9 +47,7 @@ class StreamSession(Base):
     platform: Mapped[str | None] = mapped_column(String, nullable=True)
     started_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow, nullable=False)
     ended_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
-    status: Mapped[str] = mapped_column(
-        String, default=StreamSessionStatus.ACTIVE.value, nullable=False
-    )
+    status: Mapped[str] = mapped_column(String, default=StreamSessionStatus.ACTIVE.value, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow, nullable=False)
 
     user: Mapped[User] = relationship("User")

--- a/app/models/stream_session_models.py
+++ b/app/models/stream_session_models.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from sqlalchemy import DateTime, ForeignKey, Index, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.config.database.session import Base
+from app.utils.datetime_utils import utcnow
+
+if TYPE_CHECKING:
+    from app.models.user_models import User
+
+
+class StreamSessionStatus(str, Enum):
+    ACTIVE = "active"
+    ENDED = "ended"
+    FAILED = "failed"
+
+
+class StreamSession(Base):
+    """Historical record of a broadcast session.
+
+    Redis remains the source of truth for live tracking. This table is written
+    best-effort alongside Redis so the admin dashboard can report lifetime and
+    period totals beyond the 24h Redis TTL.
+    """
+
+    __tablename__ = "stream_sessions"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        nullable=False,
+    )
+    stream_id: Mapped[str] = mapped_column(String, nullable=False, unique=True, index=True)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    platform: Mapped[str | None] = mapped_column(String, nullable=True)
+    started_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow, nullable=False)
+    ended_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    status: Mapped[str] = mapped_column(
+        String, default=StreamSessionStatus.ACTIVE.value, nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow, nullable=False)
+
+    user: Mapped[User] = relationship("User")
+
+    __table_args__ = (
+        Index("ix_stream_sessions_user_started", "user_id", "started_at"),
+        Index("ix_stream_sessions_platform_started", "platform", "started_at"),
+        Index("ix_stream_sessions_status", "status"),
+    )

--- a/app/models/user_models.py
+++ b/app/models/user_models.py
@@ -106,6 +106,16 @@ class User(Base):
         """Check if user has admin role"""
         return self.has_role("admin")
 
+    def is_super_admin(self) -> bool:
+        """Check if user has the platform-wide super_admin role.
+
+        Use this for endpoints that should be restricted to the platform owner /
+        back office (analytics, cross-tenant user management, infra controls).
+        The `is_admin()` helper is reserved for the (future) organization-scoped
+        admin tier.
+        """
+        return self.has_role("super_admin")
+
     def is_moderator(self) -> bool:
         """Check if user has moderator role"""
         return self.has_role("moderator")

--- a/app/services/admin_analytics_service.py
+++ b/app/services/admin_analytics_service.py
@@ -27,15 +27,9 @@ class AdminAnalyticsService:
         d30 = now - timedelta(days=30)
 
         total = (await db.execute(select(func.count(User.id)))).scalar_one()
-        active = (
-            await db.execute(select(func.count(User.id)).where(User.is_active.is_(True)))
-        ).scalar_one()
-        new_7d = (
-            await db.execute(select(func.count(User.id)).where(User.created_at >= d7))
-        ).scalar_one()
-        new_30d = (
-            await db.execute(select(func.count(User.id)).where(User.created_at >= d30))
-        ).scalar_one()
+        active = (await db.execute(select(func.count(User.id)).where(User.is_active.is_(True)))).scalar_one()
+        new_7d = (await db.execute(select(func.count(User.id)).where(User.created_at >= d7))).scalar_one()
+        new_30d = (await db.execute(select(func.count(User.id)).where(User.created_at >= d30))).scalar_one()
 
         # Role breakdown: roles is comma-separated, so compute in Python over a
         # lightweight projection. Population is small (admins/moderators); avoid
@@ -49,11 +43,7 @@ class AdminAnalyticsService:
                 if r:
                     by_role[r] = by_role.get(r, 0) + 1
 
-        latest_q = (
-            select(User)
-            .order_by(User.created_at.desc())
-            .limit(5)
-        )
+        latest_q = select(User).order_by(User.created_at.desc()).limit(5)
         latest = (await db.execute(latest_q)).scalars().all()
 
         return {
@@ -83,24 +73,16 @@ class AdminAnalyticsService:
         d30 = now - timedelta(days=30)
 
         total = (await db.execute(select(func.count(Event.id)))).scalar_one()
-        created_7d = (
-            await db.execute(select(func.count(Event.id)).where(Event.created_at >= d7))
-        ).scalar_one()
-        created_30d = (
-            await db.execute(select(func.count(Event.id)).where(Event.created_at >= d30))
-        ).scalar_one()
+        created_7d = (await db.execute(select(func.count(Event.id)).where(Event.created_at >= d7))).scalar_one()
+        created_30d = (await db.execute(select(func.count(Event.id)).where(Event.created_at >= d30))).scalar_one()
 
-        status_rows = (
-            await db.execute(select(Event.status, func.count(Event.id)).group_by(Event.status))
-        ).all()
+        status_rows = (await db.execute(select(Event.status, func.count(Event.id)).group_by(Event.status))).all()
         by_status: dict[str, int] = {s.value if hasattr(s, "value") else str(s): c for s, c in status_rows}
         for s in EventStatus:
             by_status.setdefault(s.value, 0)
 
         bbb_total = (await db.execute(select(func.count(BbbMeeting.id)))).scalar_one()
-        bbb_30d = (
-            await db.execute(select(func.count(BbbMeeting.id)).where(BbbMeeting.created_at >= d30))
-        ).scalar_one()
+        bbb_30d = (await db.execute(select(func.count(BbbMeeting.id)).where(BbbMeeting.created_at >= d30))).scalar_one()
 
         latest_q = select(Event).order_by(Event.created_at.desc()).limit(5)
         latest = (await db.execute(latest_q)).scalars().all()
@@ -133,20 +115,14 @@ class AdminAnalyticsService:
 
         total = (await db.execute(select(func.count(StreamSession.id)))).scalar_one()
         sessions_24h = (
-            await db.execute(
-                select(func.count(StreamSession.id)).where(StreamSession.started_at >= d1)
-            )
+            await db.execute(select(func.count(StreamSession.id)).where(StreamSession.started_at >= d1))
         ).scalar_one()
         sessions_30d = (
-            await db.execute(
-                select(func.count(StreamSession.id)).where(StreamSession.started_at >= d30)
-            )
+            await db.execute(select(func.count(StreamSession.id)).where(StreamSession.started_at >= d30))
         ).scalar_one()
         active_now = (
             await db.execute(
-                select(func.count(StreamSession.id)).where(
-                    StreamSession.status == StreamSessionStatus.ACTIVE.value
-                )
+                select(func.count(StreamSession.id)).where(StreamSession.status == StreamSessionStatus.ACTIVE.value)
             )
         ).scalar_one()
 
@@ -199,16 +175,12 @@ class AdminAnalyticsService:
         d30 = now - timedelta(days=30)
 
         plan_rows = (
-            await db.execute(
-                select(Subscription.plan, func.count(Subscription.id)).group_by(Subscription.plan)
-            )
+            await db.execute(select(Subscription.plan, func.count(Subscription.id)).group_by(Subscription.plan))
         ).all()
         subs_by_plan: dict[str, int] = {p: c for p, c in plan_rows}
 
         status_rows = (
-            await db.execute(
-                select(Subscription.status, func.count(Subscription.id)).group_by(Subscription.status)
-            )
+            await db.execute(select(Subscription.status, func.count(Subscription.id)).group_by(Subscription.status))
         ).all()
         subs_by_status: dict[str, int] = {s: c for s, c in status_rows}
 
@@ -237,9 +209,7 @@ class AdminAnalyticsService:
         ).scalar_one()
 
         transactions_30d_count = (
-            await db.execute(
-                select(func.count(Transaction.id)).where(Transaction.created_at >= d30)
-            )
+            await db.execute(select(func.count(Transaction.id)).where(Transaction.created_at >= d30))
         ).scalar_one()
 
         failed_payments_7d = (

--- a/app/services/admin_analytics_service.py
+++ b/app/services/admin_analytics_service.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config.logger_config import get_logger
+from app.models.bbb_models import BbbMeeting
+from app.models.connection_model import Connection
+from app.models.event.event_models import Event, EventStatus
+from app.models.payment_models import Subscription, SubscriptionStatus, Transaction
+from app.models.stream_session_models import StreamSession, StreamSessionStatus
+from app.models.user_models import User
+from app.utils.datetime_utils import utcnow
+
+logger = get_logger("AdminAnalyticsService")
+
+
+class AdminAnalyticsService:
+    """Compute platform-wide snapshot metrics for the admin dashboard."""
+
+    @staticmethod
+    async def _users_stats(db: AsyncSession) -> dict:
+        now = utcnow()
+        d7 = now - timedelta(days=7)
+        d30 = now - timedelta(days=30)
+
+        total = (await db.execute(select(func.count(User.id)))).scalar_one()
+        active = (
+            await db.execute(select(func.count(User.id)).where(User.is_active.is_(True)))
+        ).scalar_one()
+        new_7d = (
+            await db.execute(select(func.count(User.id)).where(User.created_at >= d7))
+        ).scalar_one()
+        new_30d = (
+            await db.execute(select(func.count(User.id)).where(User.created_at >= d30))
+        ).scalar_one()
+
+        # Role breakdown: roles is comma-separated, so compute in Python over a
+        # lightweight projection. Population is small (admins/moderators); avoid
+        # complex SQL string-splitting that doesn't port cleanly across dialects.
+        rows = (await db.execute(select(User.roles))).scalars().all()
+        by_role: dict[str, int] = {}
+        for raw in rows:
+            if not raw:
+                continue
+            for r in (s.strip() for s in raw.split(",")):
+                if r:
+                    by_role[r] = by_role.get(r, 0) + 1
+
+        latest_q = (
+            select(User)
+            .order_by(User.created_at.desc())
+            .limit(5)
+        )
+        latest = (await db.execute(latest_q)).scalars().all()
+
+        return {
+            "total": total,
+            "active": active,
+            "inactive": total - active,
+            "new_7d": new_7d,
+            "new_30d": new_30d,
+            "by_role": by_role,
+            "latest": [
+                {
+                    "id": str(u.id),
+                    "username": u.username,
+                    "email": u.email,
+                    "roles": u.roles,
+                    "created_at": u.created_at,
+                    "is_active": u.is_active,
+                }
+                for u in latest
+            ],
+        }
+
+    @staticmethod
+    async def _events_stats(db: AsyncSession) -> dict:
+        now = utcnow()
+        d7 = now - timedelta(days=7)
+        d30 = now - timedelta(days=30)
+
+        total = (await db.execute(select(func.count(Event.id)))).scalar_one()
+        created_7d = (
+            await db.execute(select(func.count(Event.id)).where(Event.created_at >= d7))
+        ).scalar_one()
+        created_30d = (
+            await db.execute(select(func.count(Event.id)).where(Event.created_at >= d30))
+        ).scalar_one()
+
+        status_rows = (
+            await db.execute(select(Event.status, func.count(Event.id)).group_by(Event.status))
+        ).all()
+        by_status: dict[str, int] = {s.value if hasattr(s, "value") else str(s): c for s, c in status_rows}
+        for s in EventStatus:
+            by_status.setdefault(s.value, 0)
+
+        bbb_total = (await db.execute(select(func.count(BbbMeeting.id)))).scalar_one()
+        bbb_30d = (
+            await db.execute(select(func.count(BbbMeeting.id)).where(BbbMeeting.created_at >= d30))
+        ).scalar_one()
+
+        latest_q = select(Event).order_by(Event.created_at.desc()).limit(5)
+        latest = (await db.execute(latest_q)).scalars().all()
+
+        return {
+            "total": total,
+            "by_status": by_status,
+            "created_7d": created_7d,
+            "created_30d": created_30d,
+            "bbb_meetings_total": bbb_total,
+            "bbb_meetings_30d": bbb_30d,
+            "latest": [
+                {
+                    "id": str(e.id),
+                    "title": e.title,
+                    "status": e.status.value if hasattr(e.status, "value") else str(e.status),
+                    "start_date": e.start_date,
+                    "creator_id": str(e.creator_id),
+                    "created_at": e.created_at,
+                }
+                for e in latest
+            ],
+        }
+
+    @staticmethod
+    async def _streaming_stats(db: AsyncSession) -> dict:
+        now = utcnow()
+        d1 = now - timedelta(days=1)
+        d30 = now - timedelta(days=30)
+
+        total = (await db.execute(select(func.count(StreamSession.id)))).scalar_one()
+        sessions_24h = (
+            await db.execute(
+                select(func.count(StreamSession.id)).where(StreamSession.started_at >= d1)
+            )
+        ).scalar_one()
+        sessions_30d = (
+            await db.execute(
+                select(func.count(StreamSession.id)).where(StreamSession.started_at >= d30)
+            )
+        ).scalar_one()
+        active_now = (
+            await db.execute(
+                select(func.count(StreamSession.id)).where(
+                    StreamSession.status == StreamSessionStatus.ACTIVE.value
+                )
+            )
+        ).scalar_one()
+
+        platform_rows = (
+            await db.execute(
+                select(StreamSession.platform, func.count(StreamSession.id))
+                .where(StreamSession.started_at >= d30)
+                .group_by(StreamSession.platform)
+            )
+        ).all()
+        by_platform: dict[str, int] = {(p or "unknown"): c for p, c in platform_rows}
+
+        conn_rows = (
+            await db.execute(
+                select(Connection.provider, func.count(Connection.id))
+                .where(Connection.revoked_at.is_(None))
+                .group_by(Connection.provider)
+            )
+        ).all()
+        connections_by_provider: dict[str, int] = {p: c for p, c in conn_rows}
+
+        latest_q = select(StreamSession).order_by(StreamSession.started_at.desc()).limit(5)
+        latest = (await db.execute(latest_q)).scalars().all()
+
+        return {
+            "sessions_total": total,
+            "sessions_24h": sessions_24h,
+            "sessions_30d": sessions_30d,
+            "active_now": active_now,
+            "by_platform": by_platform,
+            "connections_by_provider": connections_by_provider,
+            "latest": [
+                {
+                    "id": str(s.id),
+                    "stream_id": s.stream_id,
+                    "user_id": str(s.user_id),
+                    "platform": s.platform,
+                    "status": s.status,
+                    "started_at": s.started_at,
+                    "ended_at": s.ended_at,
+                }
+                for s in latest
+            ],
+        }
+
+    @staticmethod
+    async def _revenue_stats(db: AsyncSession) -> dict:
+        now = utcnow()
+        d7 = now - timedelta(days=7)
+        d30 = now - timedelta(days=30)
+
+        plan_rows = (
+            await db.execute(
+                select(Subscription.plan, func.count(Subscription.id)).group_by(Subscription.plan)
+            )
+        ).all()
+        subs_by_plan: dict[str, int] = {p: c for p, c in plan_rows}
+
+        status_rows = (
+            await db.execute(
+                select(Subscription.status, func.count(Subscription.id)).group_by(Subscription.status)
+            )
+        ).all()
+        subs_by_status: dict[str, int] = {s: c for s, c in status_rows}
+
+        active_subs = (
+            await db.execute(
+                select(func.count(Subscription.id)).where(
+                    Subscription.status.in_(
+                        [
+                            SubscriptionStatus.ACTIVE.value,
+                            SubscriptionStatus.TRIALING.value,
+                        ]
+                    )
+                )
+            )
+        ).scalar_one()
+
+        # Revenue: sum of successful 'payment' transactions in last 30 days
+        revenue_30d = (
+            await db.execute(
+                select(func.coalesce(func.sum(Transaction.amount), 0.0)).where(
+                    Transaction.created_at >= d30,
+                    Transaction.transaction_type == "payment",
+                    Transaction.status.in_(["succeeded", "paid", "complete"]),
+                )
+            )
+        ).scalar_one()
+
+        transactions_30d_count = (
+            await db.execute(
+                select(func.count(Transaction.id)).where(Transaction.created_at >= d30)
+            )
+        ).scalar_one()
+
+        failed_payments_7d = (
+            await db.execute(
+                select(func.count(Transaction.id)).where(
+                    Transaction.created_at >= d7,
+                    Transaction.transaction_type.in_(["failed"]),
+                )
+            )
+        ).scalar_one()
+
+        latest_q = select(Transaction).order_by(Transaction.created_at.desc()).limit(5)
+        latest = (await db.execute(latest_q)).scalars().all()
+
+        return {
+            "subs_by_plan": subs_by_plan,
+            "subs_by_status": subs_by_status,
+            "active_subscriptions": active_subs,
+            "revenue_30d_usd": float(revenue_30d or 0.0),
+            "transactions_30d_count": transactions_30d_count,
+            "failed_payments_7d": failed_payments_7d,
+            "latest_transactions": [
+                {
+                    "id": str(t.id),
+                    "amount": t.amount,
+                    "currency": t.currency,
+                    "status": t.status,
+                    "transaction_type": t.transaction_type,
+                    "created_at": t.created_at,
+                }
+                for t in latest
+            ],
+        }
+
+    @classmethod
+    async def get_overview(cls, db: AsyncSession) -> dict:
+        return {
+            "generated_at": utcnow(),
+            "users": await cls._users_stats(db),
+            "events": await cls._events_stats(db),
+            "streaming": await cls._streaming_stats(db),
+            "revenue": await cls._revenue_stats(db),
+        }

--- a/app/services/broadcaster_service.py
+++ b/app/services/broadcaster_service.py
@@ -6,8 +6,9 @@ import requests
 from fastapi import HTTPException
 from fastapi.concurrency import run_in_threadpool
 from requests import Timeout as RequestsTimeout
-from sqlalchemy import select
+from sqlalchemy import select, update
 
+from app.config.database.session import SessionLocal
 from app.config.redis_config import cache
 from app.config.settings import get_settings
 from app.models.bbb_schemas import (
@@ -18,14 +19,51 @@ from app.models.bbb_schemas import (
     PluginManifests,
     StreamConfig,
 )
+from app.models.stream_session_models import StreamSession, StreamSessionStatus
 from app.models.user_models import User
 from app.services.bbb_service import BBBService
 from app.services.chat_gateway_client import chat_gateway_client
 from app.services.payment_service import PaymentService
+from app.utils.datetime_utils import utcnow
 
 logger = logging.getLogger("BroadcasterService")
 
 _STREAM_TTL = 86400  # 24 hours
+
+
+async def _record_stream_session_start(user_id: str, stream_id: str, platform: str | None) -> None:
+    """Best-effort persistence of stream start for admin analytics."""
+    try:
+        import uuid as _uuid
+
+        async with SessionLocal() as db:
+            session = StreamSession(
+                stream_id=stream_id,
+                user_id=_uuid.UUID(user_id),
+                platform=platform,
+                status=StreamSessionStatus.ACTIVE.value,
+            )
+            db.add(session)
+            await db.commit()
+    except Exception as e:
+        logger.warning(f"Failed to persist stream session start ({stream_id}): {e}")
+
+
+async def _record_stream_session_end(stream_id: str) -> None:
+    """Best-effort update marking the stream session as ended."""
+    try:
+        async with SessionLocal() as db:
+            await db.execute(
+                update(StreamSession)
+                .where(
+                    StreamSession.stream_id == stream_id,
+                    StreamSession.status == StreamSessionStatus.ACTIVE.value,
+                )
+                .values(ended_at=utcnow(), status=StreamSessionStatus.ENDED.value)
+            )
+            await db.commit()
+    except Exception as e:
+        logger.warning(f"Failed to persist stream session end ({stream_id}): {e}")
 
 
 class StreamTracker:
@@ -39,6 +77,9 @@ class StreamTracker:
     @staticmethod
     async def add_stream(user_id: str, stream_id: str, platform: str | None = None) -> None:
         """Register a new active stream"""
+        # Persist to DB for historical analytics (best-effort; Redis remains source of truth)
+        await _record_stream_session_start(user_id, stream_id, platform)
+
         try:
             if cache.redis_client:
                 await cache.sadd(f"streams:user:{user_id}", stream_id)
@@ -59,6 +100,9 @@ class StreamTracker:
     @staticmethod
     async def remove_stream(stream_id: str) -> tuple[str | None, str | None]:
         """Remove a stream, returns (user_id, platform)"""
+        # Mark session as ended in DB (best-effort)
+        await _record_stream_session_end(stream_id)
+
         user_id = None
         platform = None
 

--- a/scripts/create_super_admin_user.py
+++ b/scripts/create_super_admin_user.py
@@ -85,9 +85,7 @@ async def create_super_admin_user(
                 "lastName": last_name,
                 "enabled": True,
                 "emailVerified": True,
-                "credentials": [
-                    {"type": "password", "value": password, "temporary": False}
-                ],
+                "credentials": [{"type": "password", "value": password, "temporary": False}],
             }
         )
         print(f"   ✅ Keycloak user created — ID: {keycloak_id}")
@@ -100,9 +98,7 @@ async def create_super_admin_user(
                 keycloak_id = users[0]["id"]
                 print(f"   ℹ️  Keycloak user already exists — ID: {keycloak_id}")
                 try:
-                    kc_admin.set_user_password(
-                        user_id=keycloak_id, password=password, temporary=False
-                    )
+                    kc_admin.set_user_password(user_id=keycloak_id, password=password, temporary=False)
                     print("   ✅ Password reset to requested value")
                 except Exception as pw_err:
                     print(f"   ⚠️  Could not reset password: {pw_err}")
@@ -121,9 +117,7 @@ async def create_super_admin_user(
         kc_admin.get_realm_role(TARGET_ROLE)
         print(f"   ℹ️  Realm role '{TARGET_ROLE}' already exists")
     except Exception:
-        kc_admin.create_realm_role(
-            {"name": TARGET_ROLE, "description": "Platform-wide back-office admin"}
-        )
+        kc_admin.create_realm_role({"name": TARGET_ROLE, "description": "Platform-wide back-office admin"})
         print(f"   ✅ Created realm role '{TARGET_ROLE}'")
 
     # ── Step 3: Assign `super_admin` and strip legacy `admin` ───────
@@ -136,9 +130,7 @@ async def create_super_admin_user(
         legacy_role = kc_admin.get_realm_role(LEGACY_ROLE)
         current_roles = kc_admin.get_realm_roles_of_user(user_id=keycloak_id)
         if any(r.get("name") == LEGACY_ROLE for r in current_roles):
-            kc_admin.delete_realm_roles_of_user(
-                user_id=keycloak_id, roles=[legacy_role]
-            )
+            kc_admin.delete_realm_roles_of_user(user_id=keycloak_id, roles=[legacy_role])
             print(f"   ✅ Removed stale '{LEGACY_ROLE}' realm role assignment")
     except Exception:
         # Legacy role doesn't exist or user never had it — both fine.

--- a/scripts/create_super_admin_user.py
+++ b/scripts/create_super_admin_user.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""
+Create a SUPER ADMIN user in Keycloak + the local DB.
+
+A super_admin has platform-wide back-office access (analytics, cross-tenant
+user management, infra controls). The `admin` role is reserved for the future
+organization-scoped admin tier.
+
+- Creates (or reuses) the Keycloak user
+- Ensures the `super_admin` realm role exists, then assigns it to the user
+  (so the JWT's realm_access.roles contains "super_admin", which the frontend
+  middleware checks before letting /admin pages render)
+- If the user previously had the bare `admin` role, that assignment is removed
+  so role membership stays clean during the role-model migration
+- Creates (or updates) the matching local DB row with roles="super_admin"
+
+Usage:
+    python scripts/create_super_admin_user.py
+    python scripts/create_super_admin_user.py --email admin@admin.com --password admin
+"""
+
+import asyncio
+import sys
+
+from keycloak import KeycloakAdmin
+from keycloak.exceptions import KeycloakPostError
+from sqlalchemy import select
+
+from app.config.database.session import SessionLocal
+from app.config.settings import get_settings, verify_ssl
+
+# Import all models so SQLAlchemy can resolve string-based relationships
+# on the User mapper (Subscription, Notification, FCMToken, etc.).
+from app.models import (  # noqa: F401
+    bbb_models,
+    channel,
+    connection_model,
+    event,
+    fcm_token_model,
+    notification_models,
+    payment_models,
+    stream_models,
+    stream_session_models,
+)
+from app.models.user_models import User
+
+DEFAULT_EMAIL = "admin@admin.com"
+DEFAULT_USERNAME = "admin"
+DEFAULT_FIRST_NAME = "Super"
+DEFAULT_LAST_NAME = "Admin"
+DEFAULT_PASSWORD = "admin"
+
+TARGET_ROLE = "super_admin"
+LEGACY_ROLE = "admin"  # If the user still has this from before the rename, strip it.
+
+
+async def create_super_admin_user(
+    email: str,
+    username: str,
+    first_name: str,
+    last_name: str,
+    password: str,
+) -> None:
+    settings = get_settings()
+
+    kc_admin = KeycloakAdmin(
+        server_url=settings.keycloak_server_url,
+        username=settings.keycloak_admin_username,
+        password=settings.keycloak_admin_password,
+        realm_name=settings.keycloak_realm,
+        user_realm_name="master",
+        verify=verify_ssl,
+    )
+
+    # ── Step 1: Create (or reuse) Keycloak user ─────────────────────
+    print("\n🔑 Creating user in Keycloak …")
+    keycloak_id: str | None = None
+
+    try:
+        keycloak_id = kc_admin.create_user(
+            {
+                "email": email,
+                "username": username,
+                "firstName": first_name,
+                "lastName": last_name,
+                "enabled": True,
+                "emailVerified": True,
+                "credentials": [
+                    {"type": "password", "value": password, "temporary": False}
+                ],
+            }
+        )
+        print(f"   ✅ Keycloak user created — ID: {keycloak_id}")
+    except KeycloakPostError as e:
+        if "User exists" in str(e) or "409" in str(e):
+            users = kc_admin.get_users({"username": username, "exact": True})
+            if not users:
+                users = kc_admin.get_users({"email": email, "exact": True})
+            if users:
+                keycloak_id = users[0]["id"]
+                print(f"   ℹ️  Keycloak user already exists — ID: {keycloak_id}")
+                try:
+                    kc_admin.set_user_password(
+                        user_id=keycloak_id, password=password, temporary=False
+                    )
+                    print("   ✅ Password reset to requested value")
+                except Exception as pw_err:
+                    print(f"   ⚠️  Could not reset password: {pw_err}")
+            else:
+                print("   ❌ User exists in Keycloak but lookup failed.")
+                return
+        else:
+            print(f"   ❌ Keycloak error: {e}")
+            return
+
+    assert keycloak_id is not None
+
+    # ── Step 2: Ensure the `super_admin` realm role exists ──────────
+    print(f"\n🛡️  Ensuring '{TARGET_ROLE}' realm role exists …")
+    try:
+        kc_admin.get_realm_role(TARGET_ROLE)
+        print(f"   ℹ️  Realm role '{TARGET_ROLE}' already exists")
+    except Exception:
+        kc_admin.create_realm_role(
+            {"name": TARGET_ROLE, "description": "Platform-wide back-office admin"}
+        )
+        print(f"   ✅ Created realm role '{TARGET_ROLE}'")
+
+    # ── Step 3: Assign `super_admin` and strip legacy `admin` ───────
+    print(f"\n🎟️  Assigning '{TARGET_ROLE}' realm role …")
+    target_role = kc_admin.get_realm_role(TARGET_ROLE)
+    kc_admin.assign_realm_roles(user_id=keycloak_id, roles=[target_role])
+    print("   ✅ Role assigned")
+
+    try:
+        legacy_role = kc_admin.get_realm_role(LEGACY_ROLE)
+        current_roles = kc_admin.get_realm_roles_of_user(user_id=keycloak_id)
+        if any(r.get("name") == LEGACY_ROLE for r in current_roles):
+            kc_admin.delete_realm_roles_of_user(
+                user_id=keycloak_id, roles=[legacy_role]
+            )
+            print(f"   ✅ Removed stale '{LEGACY_ROLE}' realm role assignment")
+    except Exception:
+        # Legacy role doesn't exist or user never had it — both fine.
+        pass
+
+    # ── Step 4: Create (or update) the local DB row ─────────────────
+    print("\n💾 Syncing user into local DB …")
+    async with SessionLocal() as session:
+        result = await session.execute(select(User).where(User.keycloak_id == keycloak_id))
+        user = result.scalar_one_or_none()
+
+        if user:
+            user.email = email
+            user.username = username
+            user.first_name = first_name
+            user.last_name = last_name
+            existing_roles = set(user.get_roles_list())
+            existing_roles.discard(LEGACY_ROLE)  # strip stale `admin`
+            existing_roles.add(TARGET_ROLE)
+            user.set_roles_list(sorted(existing_roles))
+            user.is_active = True
+            print(f"   ℹ️  Updated existing DB user — ID: {user.id} (roles: {user.roles})")
+        else:
+            user = User(
+                keycloak_id=keycloak_id,
+                email=email,
+                username=username,
+                first_name=first_name,
+                last_name=last_name,
+                roles=TARGET_ROLE,
+                is_active=True,
+            )
+            session.add(user)
+            await session.flush()
+            print(f"   ✅ Created DB user — ID: {user.id}")
+
+        await session.commit()
+
+    print("\n" + "=" * 60)
+    print("  ✅ Super Admin user is ready")
+    print("=" * 60)
+    print(f"  Email:        {email}")
+    print(f"  Username:     {username}")
+    print(f"  Password:     {password}")
+    print(f"  Keycloak ID:  {keycloak_id}")
+    print(f"  DB role:      {TARGET_ROLE}")
+    print(f"  Realm role:   {TARGET_ROLE}")
+    print("=" * 60)
+    print("\n  👉 Log in at the frontend; the 'Admin' link should appear\n")
+
+
+async def main() -> None:
+    email = DEFAULT_EMAIL
+    password = DEFAULT_PASSWORD
+    username = DEFAULT_USERNAME
+
+    args = sys.argv[1:]
+    i = 0
+    while i < len(args):
+        if args[i] == "--email" and i + 1 < len(args):
+            email = args[i + 1]
+            username = email.split("@")[0].replace(".", "_").replace("+", "_")
+            i += 2
+        elif args[i] == "--password" and i + 1 < len(args):
+            password = args[i + 1]
+            i += 2
+        elif args[i] == "--username" and i + 1 < len(args):
+            username = args[i + 1]
+            i += 2
+        else:
+            i += 1
+
+    await create_super_admin_user(
+        email=email,
+        username=username,
+        first_name=DEFAULT_FIRST_NAME,
+        last_name=DEFAULT_LAST_NAME,
+        password=password,
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/controllers/test_user_permissions.py
+++ b/tests/controllers/test_user_permissions.py
@@ -57,8 +57,8 @@ class DummyUser:
 
 
 @pytest.mark.anyio
-async def test_users_allowed_for_admin(client, monkeypatch):
-    app.dependency_overrides[user_controller.get_current_user] = lambda: DummyUser("admin", roles=["admin"])
+async def test_users_allowed_for_super_admin(client, monkeypatch):
+    app.dependency_overrides[user_controller.get_current_user] = lambda: DummyUser("admin", roles=["super_admin"])
     try:
         # Return minimal, schema-like user dict
         async def fake_get_users(skip, limit, db):
@@ -87,7 +87,7 @@ async def test_users_allowed_for_admin(client, monkeypatch):
 
 
 @pytest.mark.anyio
-async def test_cache_stats_forbidden_for_non_admin(client):
+async def test_cache_stats_forbidden_for_non_super_admin(client):
     app.dependency_overrides[user_controller.get_current_user] = lambda: DummyUser("viewer", roles=["viewer"])
     try:
         resp = await client.get("/api/cache/stats")
@@ -97,8 +97,8 @@ async def test_cache_stats_forbidden_for_non_admin(client):
 
 
 @pytest.mark.anyio
-async def test_cache_stats_allowed_for_admin(client, monkeypatch):
-    app.dependency_overrides[user_controller.get_current_user] = lambda: DummyUser("admin", roles=["admin"])
+async def test_cache_stats_allowed_for_super_admin(client, monkeypatch):
+    app.dependency_overrides[user_controller.get_current_user] = lambda: DummyUser("admin", roles=["super_admin"])
     try:
 
         async def ok_health():


### PR DESCRIPTION
## Summary

Adds an admin-only platform analytics dashboard endpoint and introduces a
two-tier admin model so the platform owner / back office can be distinguished
from a future organization-scoped admin tier.

- `GET /api/admin/analytics/overview` — single endpoint returning snapshot
  KPIs across **users**, **events**, **streaming**, and **revenue** (subscriptions
  by plan/status, 30d revenue from successful transactions, failed payments,
  recent activity lists). Gated by the new `super_admin` realm role.
- New `stream_sessions` table — historical record of broadcast sessions.
  Previously stream/broadcast state lived only in Redis with a 24h TTL, so
  lifetime/period metrics were impossible. `StreamTracker.add_stream` and
  `remove_stream` now write the session row best-effort (Redis remains the
  source of truth for live tracking; DB writes cannot break the broadcast path).
- Role split — `require_role("admin")` on the existing platform-wide
  endpoints (user list, role update, cache controls) is renamed to
  `super_admin`. The bare `admin` role is now reserved for the future
  organization-scoped tier (university admin managing their own org's users)
  and is accepted by `PUT /api/users/{id}/role` without yet being wired to any
  capability.
- `scripts/create_super_admin_user.py` — provisioning script that creates a
  Keycloak user, ensures the `super_admin` realm role exists, assigns it,
  strips any stale `admin` assignment, and syncs the local DB row.


## Files of interest

- `app/controllers/admin_controller.py` — new endpoint, super_admin gate
- `app/services/admin_analytics_service.py` — query layer
- `app/models/stream_session_models.py` + `alembic/versions/b1c2d3e4f5a6_*.py`
- `app/services/broadcaster_service.py` — `_record_stream_session_start/end`
- `app/controllers/user_controller.py` — five `require_role` renames
- `scripts/create_super_admin_user.py`
