### PR TITLE
Feature/organizations

### DIFF
--- a/alembic/versions/c2d3e4f5a6b7_add_organizations.py
+++ b/alembic/versions/c2d3e4f5a6b7_add_organizations.py
@@ -1,0 +1,81 @@
+"""add organizations and user.organization_id
+
+Revision ID: c2d3e4f5a6b7
+Revises: b1c2d3e4f5a6
+Create Date: 2026-05-13 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c2d3e4f5a6b7"
+down_revision: Union[str, None] = "b1c2d3e4f5a6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "organizations",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name", name="uq_organizations_name"),
+    )
+    op.create_index(op.f("ix_organizations_id"), "organizations", ["id"], unique=False)
+
+    op.create_table(
+        "organization_email_domains",
+        sa.Column("domain", sa.String(), nullable=False),
+        sa.Column("organization_id", sa.UUID(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["organization_id"], ["organizations.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("domain"),
+    )
+    op.create_index(
+        op.f("ix_organization_email_domains_organization_id"),
+        "organization_email_domains",
+        ["organization_id"],
+        unique=False,
+    )
+
+    op.add_column(
+        "users",
+        sa.Column("organization_id", sa.UUID(), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_users_organization_id",
+        "users",
+        "organizations",
+        ["organization_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_index(
+        op.f("ix_users_organization_id"),
+        "users",
+        ["organization_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_users_organization_id"), table_name="users")
+    op.drop_constraint("fk_users_organization_id", "users", type_="foreignkey")
+    op.drop_column("users", "organization_id")
+
+    op.drop_index(
+        op.f("ix_organization_email_domains_organization_id"),
+        table_name="organization_email_domains",
+    )
+    op.drop_table("organization_email_domains")
+
+    op.drop_index(op.f("ix_organizations_id"), table_name="organizations")
+    op.drop_table("organizations")

--- a/alembic/versions/d3e4f5a6b7c8_add_org_onboarding.py
+++ b/alembic/versions/d3e4f5a6b7c8_add_org_onboarding.py
@@ -1,0 +1,101 @@
+"""add org onboarding: invites, domain verification, user.has_completed_onboarding
+
+Revision ID: d3e4f5a6b7c8
+Revises: c2d3e4f5a6b7
+Create Date: 2026-05-15 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d3e4f5a6b7c8"
+down_revision: Union[str, None] = "c2d3e4f5a6b7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # users.has_completed_onboarding — default False going forward; existing
+    # accounts get TRUE so they never see /onboarding retroactively.
+    op.add_column(
+        "users",
+        sa.Column(
+            "has_completed_onboarding",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+    op.execute("UPDATE users SET has_completed_onboarding = TRUE")
+    # Drop the server_default now that the backfill is done so future inserts
+    # rely on the ORM default (False) — matches the style of other bool columns.
+    op.alter_column("users", "has_completed_onboarding", server_default=None)
+
+    # organization_email_domains verification columns.
+    op.add_column(
+        "organization_email_domains",
+        sa.Column("verified_at", sa.DateTime(), nullable=True),
+    )
+    op.add_column(
+        "organization_email_domains",
+        sa.Column("verification_token", sa.String(), nullable=True),
+    )
+    op.add_column(
+        "organization_email_domains",
+        sa.Column("verification_started_at", sa.DateTime(), nullable=True),
+    )
+    # Any domain super-admin already registered is server-trusted.
+    op.execute(
+        "UPDATE organization_email_domains "
+        "SET verified_at = CURRENT_TIMESTAMP WHERE verified_at IS NULL"
+    )
+
+    # organization_invites table.
+    op.create_table(
+        "organization_invites",
+        sa.Column("code", sa.String(), nullable=False),
+        sa.Column("organization_id", sa.UUID(), nullable=False),
+        sa.Column("created_by_user_id", sa.UUID(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(), nullable=True),
+        sa.Column("expires_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["organization_id"], ["organizations.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["created_by_user_id"], ["users.id"], ondelete="SET NULL"
+        ),
+        sa.PrimaryKeyConstraint("code"),
+    )
+    op.create_index(
+        op.f("ix_organization_invites_organization_id"),
+        "organization_invites",
+        ["organization_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_organization_invites_org_active",
+        "organization_invites",
+        ["organization_id", "revoked_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_organization_invites_org_active", table_name="organization_invites"
+    )
+    op.drop_index(
+        op.f("ix_organization_invites_organization_id"),
+        table_name="organization_invites",
+    )
+    op.drop_table("organization_invites")
+
+    op.drop_column("organization_email_domains", "verification_started_at")
+    op.drop_column("organization_email_domains", "verification_token")
+    op.drop_column("organization_email_domains", "verified_at")
+
+    op.drop_column("users", "has_completed_onboarding")

--- a/app/controllers/admin_controller.py
+++ b/app/controllers/admin_controller.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -15,7 +15,7 @@ from app.models.organization_schemas import (
     OrganizationResponse,
     OrganizationUpdate,
 )
-from app.services.admin_analytics_service import AdminAnalyticsService
+from app.services.admin_analytics_service import UNASSIGNED, AdminAnalyticsService, OrgFilter
 
 logger = get_logger("AdminController")
 
@@ -27,11 +27,38 @@ router = APIRouter(
 
 
 @router.get("/analytics/overview", response_model=AnalyticsOverview)
-async def get_analytics_overview(db: AsyncSession = Depends(get_db)) -> AnalyticsOverview:
+async def get_analytics_overview(
+    organization_id: str | None = Query(
+        None,
+        description=(
+            "Optional org scope for users/events/streaming/revenue metrics. "
+            "Pass a UUID to scope to that organization, or 'unassigned' for "
+            "users with no organization. Omit for the platform-wide view. "
+            "The organizations rollup is always platform-wide."
+        ),
+    ),
+    db: AsyncSession = Depends(get_db),
+) -> AnalyticsOverview:
     """
-    Platform-wide snapshot metrics: users, events, streaming, revenue, organizations.
+    Snapshot metrics: users, events, streaming, revenue, organizations.
+
+    Per-tab metrics can be scoped by ``organization_id``. The
+    ``organizations`` rollup ignores the filter — it is the breakdown view.
     """
-    data = await AdminAnalyticsService.get_overview(db)
+    org_filter: OrgFilter = None
+    if organization_id is not None:
+        if organization_id == UNASSIGNED:
+            org_filter = UNASSIGNED
+        else:
+            try:
+                org_filter = UUID(organization_id)
+            except ValueError as e:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"organization_id must be a UUID or '{UNASSIGNED}'",
+                ) from e
+
+    data = await AdminAnalyticsService.get_overview(db, org_filter)
     return AnalyticsOverview.model_validate(data)
 
 
@@ -112,9 +139,7 @@ async def update_organization(
     if payload.is_active is not None:
         org.is_active = payload.is_active
     if payload.email_domains is not None:
-        existing = await db.execute(
-            select(OrganizationEmailDomain).where(OrganizationEmailDomain.organization_id == org_id)
-        )
+        existing = await db.execute(select(OrganizationEmailDomain).where(OrganizationEmailDomain.organization_id == org_id))
         for row in existing.scalars().all():
             await db.delete(row)
         await db.flush()

--- a/app/controllers/admin_controller.py
+++ b/app/controllers/admin_controller.py
@@ -11,11 +11,13 @@ from app.controllers.user_controller import require_role
 from app.models.admin_schemas import AnalyticsOverview
 from app.models.organization_models import Organization, OrganizationEmailDomain
 from app.models.organization_schemas import (
+    EmailDomainDetail,
     OrganizationCreate,
     OrganizationResponse,
     OrganizationUpdate,
 )
 from app.services.admin_analytics_service import UNASSIGNED, AdminAnalyticsService, OrgFilter
+from app.utils.datetime_utils import utcnow
 
 logger = get_logger("AdminController")
 
@@ -63,11 +65,20 @@ async def get_analytics_overview(
 
 
 def _serialize_org(org: Organization) -> OrganizationResponse:
+    details = [
+        EmailDomainDetail(
+            domain=d.domain,
+            verified=d.verified_at is not None,
+            verified_at=d.verified_at,
+        )
+        for d in sorted(org.email_domains, key=lambda x: x.domain)
+    ]
     return OrganizationResponse(
         id=org.id,
         name=org.name,
         is_active=org.is_active,
-        email_domains=sorted(d.domain for d in org.email_domains),
+        email_domains=[d.domain for d in details],
+        email_domain_details=details,
         created_at=org.created_at,
         updated_at=org.updated_at,
     )
@@ -89,8 +100,13 @@ async def create_organization(
     payload: OrganizationCreate,
     db: AsyncSession = Depends(get_db),
 ) -> OrganizationResponse:
+    # Super-admin-created domains are server-trusted — mark verified immediately.
+    now = utcnow()
     org = Organization(name=payload.name)
-    org.email_domains = [OrganizationEmailDomain(domain=d) for d in payload.email_domains]
+    org.email_domains = [
+        OrganizationEmailDomain(domain=d, verified_at=now)
+        for d in payload.email_domains
+    ]
     db.add(org)
     try:
         await db.commit()
@@ -143,8 +159,13 @@ async def update_organization(
         for row in existing.scalars().all():
             await db.delete(row)
         await db.flush()
+        verified_at = utcnow()
         for d in payload.email_domains:
-            db.add(OrganizationEmailDomain(domain=d, organization_id=org_id))
+            db.add(
+                OrganizationEmailDomain(
+                    domain=d, organization_id=org_id, verified_at=verified_at
+                )
+            )
 
     try:
         await db.commit()

--- a/app/controllers/admin_controller.py
+++ b/app/controllers/admin_controller.py
@@ -1,10 +1,23 @@
-from fastapi import APIRouter, Depends
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config.database.session import get_db
+from app.config.logger_config import get_logger
 from app.controllers.user_controller import require_role
 from app.models.admin_schemas import AnalyticsOverview
+from app.models.organization_models import Organization, OrganizationEmailDomain
+from app.models.organization_schemas import (
+    OrganizationCreate,
+    OrganizationResponse,
+    OrganizationUpdate,
+)
 from app.services.admin_analytics_service import AdminAnalyticsService
+
+logger = get_logger("AdminController")
 
 router = APIRouter(
     prefix="/api/admin",
@@ -16,11 +29,124 @@ router = APIRouter(
 @router.get("/analytics/overview", response_model=AnalyticsOverview)
 async def get_analytics_overview(db: AsyncSession = Depends(get_db)) -> AnalyticsOverview:
     """
-    Platform-wide snapshot metrics: users, events, streaming, revenue.
-
-    Admin-only. Returns a single payload to minimize round-trips from the
-    dashboard. Values are computed live; for caching, wrap the service call
-    in ``@cached_db`` if/when load demands it.
+    Platform-wide snapshot metrics: users, events, streaming, revenue, organizations.
     """
     data = await AdminAnalyticsService.get_overview(db)
     return AnalyticsOverview.model_validate(data)
+
+
+def _serialize_org(org: Organization) -> OrganizationResponse:
+    return OrganizationResponse(
+        id=org.id,
+        name=org.name,
+        is_active=org.is_active,
+        email_domains=sorted(d.domain for d in org.email_domains),
+        created_at=org.created_at,
+        updated_at=org.updated_at,
+    )
+
+
+async def _fetch_org_or_404(db: AsyncSession, org_id: UUID) -> Organization:
+    result = await db.execute(select(Organization).where(Organization.id == org_id))
+    org = result.scalar_one_or_none()
+    if org is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Organization {org_id} not found",
+        )
+    return org
+
+
+@router.post("/organizations", response_model=OrganizationResponse, status_code=status.HTTP_201_CREATED)
+async def create_organization(
+    payload: OrganizationCreate,
+    db: AsyncSession = Depends(get_db),
+) -> OrganizationResponse:
+    org = Organization(name=payload.name)
+    org.email_domains = [OrganizationEmailDomain(domain=d) for d in payload.email_domains]
+    db.add(org)
+    try:
+        await db.commit()
+    except IntegrityError as e:
+        await db.rollback()
+        msg = str(e.orig).lower() if e.orig else str(e).lower()
+        if "name" in msg:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"Organization name '{payload.name}' already exists.",
+            ) from e
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="One of the email domains is already claimed by another organization.",
+        ) from e
+    await db.refresh(org, attribute_names=["email_domains"])
+    return _serialize_org(org)
+
+
+@router.get("/organizations", response_model=list[OrganizationResponse])
+async def list_organizations(db: AsyncSession = Depends(get_db)) -> list[OrganizationResponse]:
+    result = await db.execute(select(Organization).order_by(Organization.name.asc()))
+    orgs = result.scalars().unique().all()
+    return [_serialize_org(o) for o in orgs]
+
+
+@router.get("/organizations/{org_id}", response_model=OrganizationResponse)
+async def get_organization(
+    org_id: UUID,
+    db: AsyncSession = Depends(get_db),
+) -> OrganizationResponse:
+    org = await _fetch_org_or_404(db, org_id)
+    return _serialize_org(org)
+
+
+@router.patch("/organizations/{org_id}", response_model=OrganizationResponse)
+async def update_organization(
+    org_id: UUID,
+    payload: OrganizationUpdate,
+    db: AsyncSession = Depends(get_db),
+) -> OrganizationResponse:
+    org = await _fetch_org_or_404(db, org_id)
+
+    if payload.name is not None:
+        org.name = payload.name
+    if payload.is_active is not None:
+        org.is_active = payload.is_active
+    if payload.email_domains is not None:
+        existing = await db.execute(
+            select(OrganizationEmailDomain).where(OrganizationEmailDomain.organization_id == org_id)
+        )
+        for row in existing.scalars().all():
+            await db.delete(row)
+        await db.flush()
+        for d in payload.email_domains:
+            db.add(OrganizationEmailDomain(domain=d, organization_id=org_id))
+
+    try:
+        await db.commit()
+    except IntegrityError as e:
+        await db.rollback()
+        msg = str(e.orig).lower() if e.orig else str(e).lower()
+        if "name" in msg:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="An organization with that name already exists.",
+            ) from e
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="One of the email domains is already claimed by another organization.",
+        ) from e
+
+    await db.refresh(org, attribute_names=["email_domains"])
+    return _serialize_org(org)
+
+
+@router.delete("/organizations/{org_id}", status_code=status.HTTP_200_OK)
+async def delete_organization(
+    org_id: UUID,
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    org = await _fetch_org_or_404(db, org_id)
+    logger.info(f"Deleting organization {org.name} (id={org.id})")
+    await db.delete(org)
+    await db.commit()
+    return {"message": "Organization deleted", "statusCode": 200}

--- a/app/controllers/admin_controller.py
+++ b/app/controllers/admin_controller.py
@@ -103,10 +103,7 @@ async def create_organization(
     # Super-admin-created domains are server-trusted — mark verified immediately.
     now = utcnow()
     org = Organization(name=payload.name)
-    org.email_domains = [
-        OrganizationEmailDomain(domain=d, verified_at=now)
-        for d in payload.email_domains
-    ]
+    org.email_domains = [OrganizationEmailDomain(domain=d, verified_at=now) for d in payload.email_domains]
     db.add(org)
     try:
         await db.commit()
@@ -161,11 +158,7 @@ async def update_organization(
         await db.flush()
         verified_at = utcnow()
         for d in payload.email_domains:
-            db.add(
-                OrganizationEmailDomain(
-                    domain=d, organization_id=org_id, verified_at=verified_at
-                )
-            )
+            db.add(OrganizationEmailDomain(domain=d, organization_id=org_id, verified_at=verified_at))
 
     try:
         await db.commit()

--- a/app/controllers/auth_controller.py
+++ b/app/controllers/auth_controller.py
@@ -185,17 +185,25 @@ async def process_user_info(user_info: dict, user_roles: list | None, db: AsyncS
         if user_roles is not None:
             new_user.set_roles_list(user_roles)
 
-        # Auto-assign organization by email domain (first login only).
-        # Manual reassignments by super-admin must persist on subsequent logins,
-        # so this lookup never runs in the `else` (existing user) branch.
+        # Auto-assign organization by email domain (first login only) — but
+        # ONLY against verified domains. Self-serve org claims that haven't
+        # cleared the DNS check don't pull in unrelated signups.
         domain = email.rpartition("@")[-1].strip().lower()
         if domain:
-            domain_row = await db.execute(select(OrganizationEmailDomain).where(OrganizationEmailDomain.domain == domain))
+            domain_row = await db.execute(
+                select(OrganizationEmailDomain).where(
+                    OrganizationEmailDomain.domain == domain,
+                    OrganizationEmailDomain.verified_at.is_not(None),
+                )
+            )
             match = domain_row.scalar_one_or_none()
             if match:
                 new_user.organization_id = match.organization_id
+                # Domain match counts as completed onboarding — they don't
+                # need to see /onboarding because they're already placed.
+                new_user.has_completed_onboarding = True
                 logger.info(
-                    f"Auto-assigned new user {new_user.username} to organization {match.organization_id} via domain {domain}"
+                    f"Auto-assigned new user {new_user.username} to organization {match.organization_id} via verified domain {domain}"
                 )
 
         db.add(new_user)

--- a/app/controllers/auth_controller.py
+++ b/app/controllers/auth_controller.py
@@ -190,9 +190,7 @@ async def process_user_info(user_info: dict, user_roles: list | None, db: AsyncS
         # so this lookup never runs in the `else` (existing user) branch.
         domain = email.rpartition("@")[-1].strip().lower()
         if domain:
-            domain_row = await db.execute(
-                select(OrganizationEmailDomain).where(OrganizationEmailDomain.domain == domain)
-            )
+            domain_row = await db.execute(select(OrganizationEmailDomain).where(OrganizationEmailDomain.domain == domain))
             match = domain_row.scalar_one_or_none()
             if match:
                 new_user.organization_id = match.organization_id

--- a/app/controllers/auth_controller.py
+++ b/app/controllers/auth_controller.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config.database.session import get_db
 from app.config.logger_config import logger
+from app.config.redis_config import cache
 from app.config.settings import get_keycloak_openid, get_settings
 from app.controllers.user_controller import get_current_user
 from app.models.auth_models import (
@@ -21,6 +22,7 @@ from app.models.auth_models import (
     TokenRequest,
     TokenResponse,
 )
+from app.models.organization_models import OrganizationEmailDomain
 from app.models.user_models import User
 from app.services.auth_service import AuthService
 from app.utils.rate_limit import limiter
@@ -171,10 +173,11 @@ async def process_user_info(user_info: dict, user_roles: list | None, db: AsyncS
 
     if not existing_user:
         # Create a new user in the database
+        email = str(user_info.get("email", ""))
         new_user = User(
             keycloak_id=str(keycloak_id),
             username=str(user_info.get("preferred_username", "")),
-            email=str(user_info.get("email", "")),
+            email=email,
             first_name=str(user_info.get("given_name", "")),
             last_name=str(user_info.get("family_name", "")),
         )
@@ -182,12 +185,31 @@ async def process_user_info(user_info: dict, user_roles: list | None, db: AsyncS
         if user_roles is not None:
             new_user.set_roles_list(user_roles)
 
+        # Auto-assign organization by email domain (first login only).
+        # Manual reassignments by super-admin must persist on subsequent logins,
+        # so this lookup never runs in the `else` (existing user) branch.
+        domain = email.rpartition("@")[-1].strip().lower()
+        if domain:
+            domain_row = await db.execute(
+                select(OrganizationEmailDomain).where(OrganizationEmailDomain.domain == domain)
+            )
+            match = domain_row.scalar_one_or_none()
+            if match:
+                new_user.organization_id = match.organization_id
+                logger.info(
+                    f"Auto-assigned new user {new_user.username} to organization {match.organization_id} via domain {domain}"
+                )
+
         db.add(new_user)
         await db.commit()
         await db.refresh(new_user)
         logger.info(
             f"New user created: {new_user.username}, with keycloak ID: {new_user.keycloak_id}, roles: {new_user.roles}"
         )
+        try:
+            await cache.delete_pattern("users_list:*")
+        except Exception as e:
+            logger.warning(f"Failed to invalidate users_list cache after new signup: {e}")
         return new_user
     else:
         # Update the existing user information

--- a/app/controllers/org_admin_controller.py
+++ b/app/controllers/org_admin_controller.py
@@ -101,13 +101,9 @@ def _serialize_org(org: Organization) -> OrganizationResponse:
                 domain=d.domain,
                 verified=verified,
                 verified_at=d.verified_at,
-                verification_record_name=(
-                    None if verified else verification_record_name(d.domain)
-                ),
+                verification_record_name=(None if verified else verification_record_name(d.domain)),
                 verification_record_value=(
-                    None
-                    if verified or not d.verification_token
-                    else verification_record_value(d.verification_token)
+                    None if verified or not d.verification_token else verification_record_value(d.verification_token)
                 ),
             )
         )
@@ -267,9 +263,7 @@ def _serialize_invite(inv: OrganizationInvite) -> OrganizationInviteResponse:
     )
 
 
-async def _active_invite_for_org(
-    db: AsyncSession, org_id: UUID
-) -> OrganizationInvite | None:
+async def _active_invite_for_org(db: AsyncSession, org_id: UUID) -> OrganizationInvite | None:
     """Find the (single) currently-active invite for an org, if any."""
     now = utcnow()
     result = await db.execute(
@@ -323,10 +317,7 @@ async def create_my_organization(
     if current_user.organization_id is not None:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail=(
-                "You already belong to an organization. Leave or be reassigned "
-                "before creating a new one."
-            ),
+            detail=("You already belong to an organization. Leave or be reassigned before creating a new one."),
         )
 
     # Step 1: Promote the caller to `admin` in Keycloak FIRST. If this fails,
@@ -334,12 +325,9 @@ async def create_my_organization(
     # auth_service raises HTTPException on failure which propagates as-is to
     # the client (typically a 500 with the Keycloak error detail).
     logger.info(
-        f"[{request_id}] Granting 'admin' role in Keycloak for {current_user.username} "
-        f"before creating org '{payload.name}'"
+        f"[{request_id}] Granting 'admin' role in Keycloak for {current_user.username} before creating org '{payload.name}'"
     )
-    await auth_service.update_user_role(
-        user_id=current_user.keycloak_id, new_role="admin"
-    )
+    await auth_service.update_user_role(user_id=current_user.keycloak_id, new_role="admin")
 
     # Step 2: Atomic DB transaction — org + domain + invite + user mutations
     # all commit together. If anything fails here we still have the Keycloak
@@ -395,9 +383,7 @@ async def create_my_organization(
     # role + org assignment. Best-effort; a Redis blip can't roll back the
     # successful commit above.
     try:
-        await user_service_cached.invalidate_user_cache(
-            target_user.id, target_user.keycloak_id
-        )
+        await user_service_cached.invalidate_user_cache(target_user.id, target_user.keycloak_id)
     except Exception as e:
         logger.warning(f"[{request_id}] Cache invalidation after org create failed: {e}")
 
@@ -420,8 +406,7 @@ async def create_my_organization(
             )
 
     logger.info(
-        f"[{request_id}] User {target_user.username} created org '{org.name}' "
-        f"with pending domain {payload.email_domain}"
+        f"[{request_id}] User {target_user.username} created org '{org.name}' with pending domain {payload.email_domain}"
     )
 
     return CreateMyOrgResponse(
@@ -456,16 +441,10 @@ async def join_my_organization(
             detail="You already belong to an organization. Switch is not supported here.",
         )
 
-    invite_result = await db.execute(
-        select(OrganizationInvite).where(OrganizationInvite.code == payload.code)
-    )
+    invite_result = await db.execute(select(OrganizationInvite).where(OrganizationInvite.code == payload.code))
     invite = invite_result.scalar_one_or_none()
     now = utcnow()
-    if (
-        invite is None
-        or invite.revoked_at is not None
-        or (invite.expires_at is not None and invite.expires_at <= now)
-    ):
+    if invite is None or invite.revoked_at is not None or (invite.expires_at is not None and invite.expires_at <= now):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Invite code is invalid or has expired.",
@@ -485,16 +464,11 @@ async def join_my_organization(
     await db.commit()
 
     try:
-        await user_service_cached.invalidate_user_cache(
-            target_user.id, target_user.keycloak_id
-        )
+        await user_service_cached.invalidate_user_cache(target_user.id, target_user.keycloak_id)
     except Exception as e:
         logger.warning(f"[{request_id}] Cache invalidation after org join failed: {e}")
 
-    logger.info(
-        f"[{request_id}] User {target_user.username} joined org '{org.name}' "
-        f"via invite {invite.code}"
-    )
+    logger.info(f"[{request_id}] User {target_user.username} joined org '{org.name}' via invite {invite.code}")
     return JoinOrgResponse(organization=_serialize_org(org))
 
 
@@ -515,9 +489,7 @@ async def skip_onboarding(
         target_user.has_completed_onboarding = True
         await db.commit()
         try:
-            await user_service_cached.invalidate_user_cache(
-                target_user.id, target_user.keycloak_id
-            )
+            await user_service_cached.invalidate_user_cache(target_user.id, target_user.keycloak_id)
         except Exception as e:
             logger.warning(f"Cache invalidation after skip-onboarding failed: {e}")
     return {"message": "Onboarding skipped", "statusCode": 200}
@@ -584,11 +556,14 @@ async def get_my_organization_invite(
     db: AsyncSession = Depends(get_db),
 ) -> OrganizationInviteResponse:
     """Return the current active invite for the caller's org, creating one on demand."""
-    invite = await _active_invite_for_org(db, current_user.organization_id)
+    # require_org_admin guarantees organization_id is set; narrow for mypy.
+    assert current_user.organization_id is not None
+    org_id = current_user.organization_id
+    invite = await _active_invite_for_org(db, org_id)
     if invite is None:
         invite = OrganizationInvite(
             code=_new_invite_code(),
-            organization_id=current_user.organization_id,
+            organization_id=org_id,
             created_by_user_id=current_user.id,
         )
         db.add(invite)
@@ -603,14 +578,17 @@ async def rotate_my_organization_invite(
     db: AsyncSession = Depends(get_db),
 ) -> OrganizationInviteResponse:
     """Revoke the current invite (if any) and create a new one."""
+    # require_org_admin guarantees organization_id is set; narrow for mypy.
+    assert current_user.organization_id is not None
+    org_id = current_user.organization_id
     now = utcnow()
-    existing = await _active_invite_for_org(db, current_user.organization_id)
+    existing = await _active_invite_for_org(db, org_id)
     if existing is not None:
         existing.revoked_at = now
 
     new_invite = OrganizationInvite(
         code=_new_invite_code(),
-        organization_id=current_user.organization_id,
+        organization_id=org_id,
         created_by_user_id=current_user.id,
     )
     db.add(new_invite)
@@ -774,7 +752,6 @@ async def delete_my_organization_domain(
     await db.delete(row)
     await db.commit()
     logger.info(
-        f"Org admin {current_user.username} removed domain {normalized} from "
-        f"organization {current_user.organization_id}"
+        f"Org admin {current_user.username} removed domain {normalized} from organization {current_user.organization_id}"
     )
     return {"message": f"Domain '{normalized}' removed.", "statusCode": 200}

--- a/app/controllers/org_admin_controller.py
+++ b/app/controllers/org_admin_controller.py
@@ -16,24 +16,47 @@ scoped to a single org and never reveals platform-wide data.
 
 from __future__ import annotations
 
+import secrets
 import uuid
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Path, status
+from fastapi import APIRouter, Depends, HTTPException, Path, Request, Response, status
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.dependencies import get_current_user
 from app.config.database.session import get_db
 from app.config.logger_config import get_logger
+from app.controllers.auth_controller import set_auth_cookies
 from app.models.admin_schemas import AnalyticsOverview
-from app.models.organization_models import Organization
-from app.models.organization_schemas import OrganizationResponse
+from app.models.organization_models import (
+    Organization,
+    OrganizationEmailDomain,
+    OrganizationInvite,
+)
+from app.models.organization_schemas import (
+    AddDomainRequest,
+    CreateMyOrgRequest,
+    CreateMyOrgResponse,
+    DomainVerificationStatus,
+    EmailDomainDetail,
+    JoinOrgRequest,
+    JoinOrgResponse,
+    OrganizationInviteResponse,
+    OrganizationResponse,
+)
 from app.models.user_models import User
 from app.models.user_schemas import UpdateUserRoleRequest, UserResponse
 from app.services.admin_analytics_service import AdminAnalyticsService
 from app.services.auth_service import AuthService
 from app.services.cached.user_service_cached import user_service_cached
+from app.services.org_verification_service import (
+    verification_record_name,
+    verification_record_value,
+    verify_domain_record,
+)
+from app.utils.datetime_utils import utcnow
 
 logger = get_logger("OrgAdminController")
 auth_service = AuthService()
@@ -70,11 +93,30 @@ async def _load_org_with_domains(db: AsyncSession, org_id: UUID) -> Organization
 
 
 def _serialize_org(org: Organization) -> OrganizationResponse:
+    details = []
+    for d in sorted(org.email_domains, key=lambda x: x.domain):
+        verified = d.verified_at is not None
+        details.append(
+            EmailDomainDetail(
+                domain=d.domain,
+                verified=verified,
+                verified_at=d.verified_at,
+                verification_record_name=(
+                    None if verified else verification_record_name(d.domain)
+                ),
+                verification_record_value=(
+                    None
+                    if verified or not d.verification_token
+                    else verification_record_value(d.verification_token)
+                ),
+            )
+        )
     return OrganizationResponse(
         id=org.id,
         name=org.name,
         is_active=org.is_active,
-        email_domains=sorted(d.domain for d in org.email_domains),
+        email_domains=[d.domain for d in details],
+        email_domain_details=details,
         created_at=org.created_at,
         updated_at=org.updated_at,
     )
@@ -202,3 +244,537 @@ async def update_my_organization_user_role(
 
     updated_user = await user_service_cached.update_user_role(user_id=user_id, new_role=new_role, db=db)
     return updated_user
+
+
+# ---------------------------------------------------------------------------
+# Self-serve onboarding
+# ---------------------------------------------------------------------------
+
+
+def _invite_join_path(code: str) -> str:
+    """The frontend route that consumes an invite code."""
+    return f"/join/org/{code}"
+
+
+def _serialize_invite(inv: OrganizationInvite) -> OrganizationInviteResponse:
+    return OrganizationInviteResponse(
+        code=inv.code,
+        organization_id=inv.organization_id,
+        created_at=inv.created_at,
+        revoked_at=inv.revoked_at,
+        expires_at=inv.expires_at,
+        join_path=_invite_join_path(inv.code),
+    )
+
+
+async def _active_invite_for_org(
+    db: AsyncSession, org_id: UUID
+) -> OrganizationInvite | None:
+    """Find the (single) currently-active invite for an org, if any."""
+    now = utcnow()
+    result = await db.execute(
+        select(OrganizationInvite)
+        .where(
+            OrganizationInvite.organization_id == org_id,
+            OrganizationInvite.revoked_at.is_(None),
+        )
+        .order_by(OrganizationInvite.created_at.desc())
+    )
+    for inv in result.scalars().all():
+        if inv.expires_at is None or inv.expires_at > now:
+            return inv
+    return None
+
+
+def _new_invite_code() -> str:
+    # 8 url-safe bytes ≈ 11 chars; collisions are astronomically unlikely but
+    # the PK constraint will catch any anyway, and the caller can retry.
+    return secrets.token_urlsafe(8)
+
+
+@router.post(
+    "/create",
+    response_model=CreateMyOrgResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_my_organization(
+    payload: CreateMyOrgRequest,
+    request: Request,
+    response: Response,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> CreateMyOrgResponse:
+    """
+    Self-serve organization creation.
+
+    The caller becomes the org's first ``admin`` and is upgraded to the
+    ``admin`` role in both Keycloak and the database atomically with the
+    org creation. We refresh the caller's auth cookies before returning so
+    their next request carries a JWT with the new role baked in — without
+    this, middleware would still see the stale ``moderator`` role and would
+    bounce them out of ``/my-org``.
+
+    The supplied email domain is stored unverified with a TXT-record token;
+    auto-match by email domain won't pick this org up until
+    ``POST /verify-domain`` succeeds.
+    """
+    request_id = str(uuid.uuid4())
+
+    if current_user.organization_id is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "You already belong to an organization. Leave or be reassigned "
+                "before creating a new one."
+            ),
+        )
+
+    # Step 1: Promote the caller to `admin` in Keycloak FIRST. If this fails,
+    # we never touch the DB — no half-created orgs, no orphan admins. The
+    # auth_service raises HTTPException on failure which propagates as-is to
+    # the client (typically a 500 with the Keycloak error detail).
+    logger.info(
+        f"[{request_id}] Granting 'admin' role in Keycloak for {current_user.username} "
+        f"before creating org '{payload.name}'"
+    )
+    await auth_service.update_user_role(
+        user_id=current_user.keycloak_id, new_role="admin"
+    )
+
+    # Step 2: Atomic DB transaction — org + domain + invite + user mutations
+    # all commit together. If anything fails here we still have the Keycloak
+    # admin grant in place (acceptable; idempotent on retry, and the user
+    # can be assigned an org later by a super-admin).
+    token = secrets.token_urlsafe(24)
+    now = utcnow()
+    org = Organization(name=payload.name)
+    org.email_domains = [
+        OrganizationEmailDomain(
+            domain=payload.email_domain,
+            verification_token=token,
+            verification_started_at=now,
+        )
+    ]
+    db.add(org)
+
+    try:
+        await db.flush()
+    except IntegrityError as e:
+        await db.rollback()
+        msg = str(e.orig).lower() if e.orig else str(e).lower()
+        if "name" in msg or "organizations_name" in msg:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"Organization name '{payload.name}' is already taken.",
+            ) from e
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="That email domain is already claimed by another organization.",
+        ) from e
+
+    # Re-fetch the caller in this session so we can mutate them safely.
+    user_result = await db.execute(select(User).where(User.id == current_user.id))
+    target_user = user_result.scalar_one()
+    target_user.organization_id = org.id
+    target_user.has_completed_onboarding = True
+    target_user.set_roles_list(["admin"])  # mirror the Keycloak grant in the DB
+
+    # Initial invite so the admin has something to share immediately.
+    invite = OrganizationInvite(
+        code=_new_invite_code(),
+        organization_id=org.id,
+        created_by_user_id=target_user.id,
+    )
+    db.add(invite)
+
+    await db.commit()
+    await db.refresh(org, attribute_names=["email_domains"])
+    await db.refresh(target_user)
+
+    # Step 3: invalidate caches so the next /api/me read reflects the new
+    # role + org assignment. Best-effort; a Redis blip can't roll back the
+    # successful commit above.
+    try:
+        await user_service_cached.invalidate_user_cache(
+            target_user.id, target_user.keycloak_id
+        )
+    except Exception as e:
+        logger.warning(f"[{request_id}] Cache invalidation after org create failed: {e}")
+
+    # Step 4: mint a fresh access_token so the caller's JWT carries the new
+    # `admin` role. Without this, middleware on the next request would read
+    # the OLD JWT (still says `moderator`) and bounce the user out of
+    # `/my-org`. The refresh_token cookie was set at login; if it's missing
+    # or rejected, we surface a soft warning — the org is still created and
+    # the user can simply sign out + back in to refresh manually.
+    refresh_cookie = request.cookies.get("refresh_token")
+    if refresh_cookie:
+        try:
+            token_data = await auth_service.refresh_token(refresh_cookie)
+            set_auth_cookies(response, token_data)
+            logger.info(f"[{request_id}] Auth cookies refreshed; new JWT carries 'admin' role")
+        except HTTPException as e:
+            logger.warning(
+                f"[{request_id}] Could not refresh auth cookies after org create "
+                f"(user should sign out and back in): {e.detail}"
+            )
+
+    logger.info(
+        f"[{request_id}] User {target_user.username} created org '{org.name}' "
+        f"with pending domain {payload.email_domain}"
+    )
+
+    return CreateMyOrgResponse(
+        organization=_serialize_org(org),
+        verification=DomainVerificationStatus(
+            domain=payload.email_domain,
+            verified=False,
+            verification_token=token,
+            verification_record_name=verification_record_name(payload.email_domain),
+            verification_record_value=verification_record_value(token),
+        ),
+    )
+
+
+@router.post("/join", response_model=JoinOrgResponse)
+async def join_my_organization(
+    payload: JoinOrgRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> JoinOrgResponse:
+    """
+    Join an organization using an invite code.
+
+    The code matches a non-revoked, non-expired ``OrganizationInvite`` row.
+    Caller's role is unchanged (defaults to moderator).
+    """
+    request_id = str(uuid.uuid4())
+
+    if current_user.organization_id is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="You already belong to an organization. Switch is not supported here.",
+        )
+
+    invite_result = await db.execute(
+        select(OrganizationInvite).where(OrganizationInvite.code == payload.code)
+    )
+    invite = invite_result.scalar_one_or_none()
+    now = utcnow()
+    if (
+        invite is None
+        or invite.revoked_at is not None
+        or (invite.expires_at is not None and invite.expires_at <= now)
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Invite code is invalid or has expired.",
+        )
+
+    org = await _load_org_with_domains(db, invite.organization_id)
+    if org is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="The organization for this invite no longer exists.",
+        )
+
+    user_result = await db.execute(select(User).where(User.id == current_user.id))
+    target_user = user_result.scalar_one()
+    target_user.organization_id = org.id
+    target_user.has_completed_onboarding = True
+    await db.commit()
+
+    try:
+        await user_service_cached.invalidate_user_cache(
+            target_user.id, target_user.keycloak_id
+        )
+    except Exception as e:
+        logger.warning(f"[{request_id}] Cache invalidation after org join failed: {e}")
+
+    logger.info(
+        f"[{request_id}] User {target_user.username} joined org '{org.name}' "
+        f"via invite {invite.code}"
+    )
+    return JoinOrgResponse(organization=_serialize_org(org))
+
+
+@router.post("/skip-onboarding")
+async def skip_onboarding(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """
+    Mark the user as having completed onboarding without joining an org.
+
+    The user remains in the 'Unassigned' bucket and a super-admin can later
+    place them via ``PATCH /api/users/{id}/organization``.
+    """
+    user_result = await db.execute(select(User).where(User.id == current_user.id))
+    target_user = user_result.scalar_one()
+    if not target_user.has_completed_onboarding:
+        target_user.has_completed_onboarding = True
+        await db.commit()
+        try:
+            await user_service_cached.invalidate_user_cache(
+                target_user.id, target_user.keycloak_id
+            )
+        except Exception as e:
+            logger.warning(f"Cache invalidation after skip-onboarding failed: {e}")
+    return {"message": "Onboarding skipped", "statusCode": 200}
+
+
+@router.post("/verify-domain", response_model=DomainVerificationStatus)
+async def verify_my_organization_domain(
+    current_user: User = Depends(require_org_admin),
+    db: AsyncSession = Depends(get_db),
+) -> DomainVerificationStatus:
+    """
+    Trigger a DNS TXT-record check for the caller's first unverified domain.
+
+    On success, ``verified_at`` is set and the token is cleared; from then on
+    new signups with that email domain will auto-match the org on first login.
+    """
+    domains_result = await db.execute(
+        select(OrganizationEmailDomain).where(
+            OrganizationEmailDomain.organization_id == current_user.organization_id,
+            OrganizationEmailDomain.verified_at.is_(None),
+        )
+    )
+    pending = domains_result.scalars().first()
+    if pending is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No pending domain to verify.",
+        )
+    if not pending.verification_token:
+        # Defensive: should never happen given the create flow, but treat as
+        # "regenerate first" if someone managed to land in this state.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="No verification token on file. Re-create the domain entry.",
+        )
+
+    verified = await verify_domain_record(pending.domain, pending.verification_token)
+    if verified:
+        pending.verified_at = utcnow()
+        token_used = pending.verification_token
+        pending.verification_token = None
+        await db.commit()
+        return DomainVerificationStatus(
+            domain=pending.domain,
+            verified=True,
+            verification_token=None,
+            verification_record_name=None,
+            verification_record_value=None,
+        )
+
+    # Not verified — return the record details again so the UI can re-display.
+    return DomainVerificationStatus(
+        domain=pending.domain,
+        verified=False,
+        verification_token=pending.verification_token,
+        verification_record_name=verification_record_name(pending.domain),
+        verification_record_value=verification_record_value(pending.verification_token),
+    )
+
+
+@router.get("/invite", response_model=OrganizationInviteResponse)
+async def get_my_organization_invite(
+    current_user: User = Depends(require_org_admin),
+    db: AsyncSession = Depends(get_db),
+) -> OrganizationInviteResponse:
+    """Return the current active invite for the caller's org, creating one on demand."""
+    invite = await _active_invite_for_org(db, current_user.organization_id)
+    if invite is None:
+        invite = OrganizationInvite(
+            code=_new_invite_code(),
+            organization_id=current_user.organization_id,
+            created_by_user_id=current_user.id,
+        )
+        db.add(invite)
+        await db.commit()
+        await db.refresh(invite)
+    return _serialize_invite(invite)
+
+
+@router.post("/invite/rotate", response_model=OrganizationInviteResponse)
+async def rotate_my_organization_invite(
+    current_user: User = Depends(require_org_admin),
+    db: AsyncSession = Depends(get_db),
+) -> OrganizationInviteResponse:
+    """Revoke the current invite (if any) and create a new one."""
+    now = utcnow()
+    existing = await _active_invite_for_org(db, current_user.organization_id)
+    if existing is not None:
+        existing.revoked_at = now
+
+    new_invite = OrganizationInvite(
+        code=_new_invite_code(),
+        organization_id=current_user.organization_id,
+        created_by_user_id=current_user.id,
+    )
+    db.add(new_invite)
+    await db.commit()
+    await db.refresh(new_invite)
+    return _serialize_invite(new_invite)
+
+
+# ---------------------------------------------------------------------------
+# Domain management — list, add, verify (per-domain)
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/domains",
+    response_model=DomainVerificationStatus,
+    status_code=status.HTTP_201_CREATED,
+)
+async def add_my_organization_domain(
+    payload: AddDomainRequest,
+    current_user: User = Depends(require_org_admin),
+    db: AsyncSession = Depends(get_db),
+) -> DomainVerificationStatus:
+    """
+    Add another email domain to the caller's organization.
+
+    The domain starts unverified with a fresh TXT-record token; the org
+    admin then publishes the record and calls
+    ``POST /domains/{domain}/verify`` to flip the status. Auto-match by
+    email domain won't pick this domain up until verified.
+    """
+    token = secrets.token_urlsafe(24)
+    new_row = OrganizationEmailDomain(
+        domain=payload.domain,
+        organization_id=current_user.organization_id,
+        verification_token=token,
+        verification_started_at=utcnow(),
+    )
+    db.add(new_row)
+    try:
+        await db.commit()
+    except IntegrityError as e:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Domain '{payload.domain}' is already claimed by another organization.",
+        ) from e
+
+    logger.info(
+        f"Org admin {current_user.username} added pending domain {payload.domain} "
+        f"to organization {current_user.organization_id}"
+    )
+
+    return DomainVerificationStatus(
+        domain=payload.domain,
+        verified=False,
+        verification_token=token,
+        verification_record_name=verification_record_name(payload.domain),
+        verification_record_value=verification_record_value(token),
+    )
+
+
+@router.post(
+    "/domains/{domain}/verify",
+    response_model=DomainVerificationStatus,
+)
+async def verify_my_organization_domain_by_name(
+    domain: str = Path(..., title="The domain to verify"),
+    current_user: User = Depends(require_org_admin),
+    db: AsyncSession = Depends(get_db),
+) -> DomainVerificationStatus:
+    """
+    Trigger a DNS TXT-record check for a specific domain on the caller's org.
+
+    Returns 404 if the domain isn't registered on this org. Idempotent —
+    a domain that's already verified is returned with ``verified=True``
+    and no DNS lookup is made.
+    """
+    normalized = domain.strip().lower().lstrip("@")
+    result = await db.execute(
+        select(OrganizationEmailDomain).where(
+            OrganizationEmailDomain.domain == normalized,
+            OrganizationEmailDomain.organization_id == current_user.organization_id,
+        )
+    )
+    row = result.scalar_one_or_none()
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Domain '{normalized}' is not registered on your organization.",
+        )
+
+    if row.verified_at is not None:
+        return DomainVerificationStatus(
+            domain=row.domain,
+            verified=True,
+            verification_token=None,
+            verification_record_name=None,
+            verification_record_value=None,
+        )
+
+    if not row.verification_token:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="No verification token on file for this domain.",
+        )
+
+    verified = await verify_domain_record(row.domain, row.verification_token)
+    if verified:
+        row.verified_at = utcnow()
+        row.verification_token = None
+        await db.commit()
+        return DomainVerificationStatus(
+            domain=row.domain,
+            verified=True,
+            verification_token=None,
+            verification_record_name=None,
+            verification_record_value=None,
+        )
+
+    return DomainVerificationStatus(
+        domain=row.domain,
+        verified=False,
+        verification_token=row.verification_token,
+        verification_record_name=verification_record_name(row.domain),
+        verification_record_value=verification_record_value(row.verification_token),
+    )
+
+
+@router.delete(
+    "/domains/{domain}",
+    status_code=status.HTTP_200_OK,
+)
+async def delete_my_organization_domain(
+    domain: str = Path(..., title="The domain to remove"),
+    current_user: User = Depends(require_org_admin),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """
+    Remove an email domain from the caller's organization.
+
+    Works for both verified and pending domains. Once deleted, the domain
+    no longer auto-attracts new signups; existing members of the org are
+    unaffected (their ``organization_id`` stays). The domain row is freed
+    up for any other organization to claim.
+    """
+    normalized = domain.strip().lower().lstrip("@")
+    result = await db.execute(
+        select(OrganizationEmailDomain).where(
+            OrganizationEmailDomain.domain == normalized,
+            OrganizationEmailDomain.organization_id == current_user.organization_id,
+        )
+    )
+    row = result.scalar_one_or_none()
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Domain '{normalized}' is not registered on your organization.",
+        )
+
+    await db.delete(row)
+    await db.commit()
+    logger.info(
+        f"Org admin {current_user.username} removed domain {normalized} from "
+        f"organization {current_user.organization_id}"
+    )
+    return {"message": f"Domain '{normalized}' removed.", "statusCode": 200}

--- a/app/controllers/org_admin_controller.py
+++ b/app/controllers/org_admin_controller.py
@@ -1,0 +1,204 @@
+"""
+Endpoints that let an authenticated user act on their *own* organization.
+
+- ``GET /api/me/organization`` — any authenticated user can read the org they
+  belong to (or get a 404 if unassigned).
+- ``GET /api/me/organization/overview`` — org-scoped analytics snapshot.
+- ``GET /api/me/organization/users`` — list members of the user's org.
+- ``PATCH /api/me/organization/users/{user_id}/role`` — change a member's
+  role within the org (limited to moderator ↔ admin).
+
+The latter three require the caller to have the ``admin`` role AND to be
+assigned to an organization. Super-admin actions still live on the
+existing ``/api/admin/*`` endpoints; this controller is intentionally
+scoped to a single org and never reveals platform-wide data.
+"""
+
+from __future__ import annotations
+
+import uuid
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Path, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.dependencies import get_current_user
+from app.config.database.session import get_db
+from app.config.logger_config import get_logger
+from app.models.admin_schemas import AnalyticsOverview
+from app.models.organization_models import Organization
+from app.models.organization_schemas import OrganizationResponse
+from app.models.user_models import User
+from app.models.user_schemas import UpdateUserRoleRequest, UserResponse
+from app.services.admin_analytics_service import AdminAnalyticsService
+from app.services.auth_service import AuthService
+from app.services.cached.user_service_cached import user_service_cached
+
+logger = get_logger("OrgAdminController")
+auth_service = AuthService()
+
+router = APIRouter(prefix="/api/me/organization", tags=["My Organization"])
+
+# Roles an org admin is allowed to assign within their own org. Promoting
+# anyone to ``super_admin`` is strictly a platform-owner action and stays on
+# the existing super-admin endpoint.
+ORG_ADMIN_MANAGEABLE_ROLES = ("moderator", "admin")
+
+
+def require_org_admin(current_user: User = Depends(get_current_user)) -> User:
+    """
+    Dependency: caller must have the ``admin`` role and be assigned to an
+    organization. Returns the caller for use in the endpoint body.
+    """
+    if not current_user.has_role("admin"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Organization admin role required.",
+        )
+    if current_user.organization_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You are not assigned to an organization.",
+        )
+    return current_user
+
+
+async def _load_org_with_domains(db: AsyncSession, org_id: UUID) -> Organization | None:
+    result = await db.execute(select(Organization).where(Organization.id == org_id))
+    return result.scalar_one_or_none()
+
+
+def _serialize_org(org: Organization) -> OrganizationResponse:
+    return OrganizationResponse(
+        id=org.id,
+        name=org.name,
+        is_active=org.is_active,
+        email_domains=sorted(d.domain for d in org.email_domains),
+        created_at=org.created_at,
+        updated_at=org.updated_at,
+    )
+
+
+@router.get("", response_model=OrganizationResponse)
+async def get_my_organization(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> OrganizationResponse:
+    """
+    Return the organization the authenticated user belongs to.
+
+    Any authenticated user can call this. 404 when the user has no org.
+    """
+    if current_user.organization_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="You are not assigned to an organization.",
+        )
+    org = await _load_org_with_domains(db, current_user.organization_id)
+    if org is None:
+        # The user's org row was deleted concurrently; treat as unassigned.
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="You are not assigned to an organization.",
+        )
+    return _serialize_org(org)
+
+
+@router.get("/overview", response_model=AnalyticsOverview)
+async def get_my_organization_overview(
+    current_user: User = Depends(require_org_admin),
+    db: AsyncSession = Depends(get_db),
+) -> AnalyticsOverview:
+    """
+    Analytics snapshot scoped to the caller's organization.
+
+    Wraps the existing ``AdminAnalyticsService.get_overview`` with an
+    ``org_filter`` of the caller's organization. The ``organizations``
+    rollup field is overwritten to contain only the caller's org row so an
+    org admin cannot see other organizations' totals.
+    """
+    data = await AdminAnalyticsService.get_overview(db, current_user.organization_id)
+
+    # Strip the platform-wide rollup down to just the caller's own org so
+    # an org admin can't enumerate other organizations' metrics.
+    org_id_str = str(current_user.organization_id)
+    data["organizations"] = [row for row in data["organizations"] if row.get("id") and str(row["id"]) == org_id_str]
+    return AnalyticsOverview.model_validate(data)
+
+
+@router.get("/users", response_model=list[UserResponse])
+async def list_my_organization_users(
+    current_user: User = Depends(require_org_admin),
+    db: AsyncSession = Depends(get_db),
+) -> list[User]:
+    """List every user assigned to the caller's organization."""
+    result = await db.execute(
+        select(User).where(User.organization_id == current_user.organization_id).order_by(User.created_at.desc())
+    )
+    return list(result.scalars().all())
+
+
+@router.patch("/users/{user_id}/role", response_model=UserResponse)
+async def update_my_organization_user_role(
+    role_data: UpdateUserRoleRequest,
+    user_id: UUID = Path(..., title="The ID of the user to update"),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_org_admin),
+):
+    """
+    Change a member's role *within* the caller's organization.
+
+    Guarded against:
+    - changing a user outside the caller's org (404, looks unfound)
+    - changing oneself (400)
+    - touching a super_admin (403)
+    - assigning anything other than moderator/admin (400)
+    """
+    request_id = str(uuid.uuid4())
+
+    target_result = await db.execute(select(User).where(User.id == user_id))
+    target_user = target_result.scalar_one_or_none()
+
+    # Pretend "not found" rather than "not in your org" — leaks no info
+    # about users outside the caller's organization.
+    if target_user is None or target_user.organization_id != current_user.organization_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"User with ID {user_id} not found in your organization.",
+        )
+
+    if target_user.id == current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="You cannot modify your own role.",
+        )
+
+    if "super_admin" in target_user.get_roles_list():
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Cannot change the role of a super admin.",
+        )
+
+    new_role = role_data.role.strip().lower()
+    if new_role not in ORG_ADMIN_MANAGEABLE_ROLES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Role '{new_role}' is not allowed. Allowed roles: {', '.join(ORG_ADMIN_MANAGEABLE_ROLES)}",
+        )
+
+    logger.info(f"[{request_id}] Org admin {current_user.username} changing role of {target_user.username} to {new_role}")
+
+    # Keycloak first, then DB — same ordering as super-admin role updates so
+    # a Keycloak failure leaves the DB untouched.
+    try:
+        await auth_service.update_user_role(user_id=target_user.keycloak_id, new_role=new_role)
+    except HTTPException as e:
+        logger.error(f"[{request_id}] Keycloak role update failed: {e.detail}")
+        raise HTTPException(
+            status_code=e.status_code,
+            detail=f"Failed to update role in Keycloak: {e.detail}",
+        ) from e
+
+    updated_user = await user_service_cached.update_user_role(user_id=user_id, new_role=new_role, db=db)
+    return updated_user

--- a/app/controllers/user_controller.py
+++ b/app/controllers/user_controller.py
@@ -236,8 +236,7 @@ async def delete_user_by_admin(
         )
 
     logger.info(
-        f"[{request_id}] Super admin {current_user.username} deleting user "
-        f"{target_user.username} (ID: {target_user.id})"
+        f"[{request_id}] Super admin {current_user.username} deleting user {target_user.username} (ID: {target_user.id})"
     )
 
     try:

--- a/app/controllers/user_controller.py
+++ b/app/controllers/user_controller.py
@@ -12,6 +12,8 @@ from app.config.database.session import get_db
 from app.config.logger_config import logger
 from app.config.redis_config import cache
 from app.config.settings import get_settings
+from app.models.organization_models import Organization
+from app.models.organization_schemas import AssignUserOrganizationRequest
 from app.models.user_models import User
 from app.models.user_schemas import (
     UpdateProfileRequest,
@@ -195,6 +197,90 @@ async def get_user_by_id(
         )
 
 
+@router.delete("/users/{user_id}")
+async def delete_user_by_admin(
+    user_id: UUID = Path(..., title="The ID of the user to delete"),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+    _: bool = Depends(require_role("super_admin")),
+):
+    """
+    Permanently delete a user (Super Admin only).
+
+    Mirrors the self-delete flow in DELETE /me:
+    1. Cancel any active Stripe subscription (best-effort)
+    2. Delete the user from Keycloak
+    3. Delete the user and all related data from the database (cascade)
+    4. Invalidate user caches
+    """
+    request_id = str(uuid.uuid4())
+
+    if user_id == current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot delete your own account from the admin panel. Use account settings instead.",
+        )
+
+    result = await db.execute(select(User).where(User.id == user_id))
+    target_user = result.scalar_one_or_none()
+    if not target_user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"User with ID {user_id} not found",
+        )
+
+    if "super_admin" in target_user.get_roles_list():
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Cannot delete another super admin.",
+        )
+
+    logger.info(
+        f"[{request_id}] Super admin {current_user.username} deleting user "
+        f"{target_user.username} (ID: {target_user.id})"
+    )
+
+    try:
+        try:
+            from app.services.payment_service import PaymentService
+
+            subscription = await PaymentService.get_user_subscription(target_user, db)
+            if subscription and subscription.stripe_subscription_id:
+                import stripe
+
+                stripe.Subscription.cancel(subscription.stripe_subscription_id)
+                logger.info(f"[{request_id}] Cancelled Stripe subscription {subscription.stripe_subscription_id}")
+        except Exception as e:
+            logger.warning(f"[{request_id}] Failed to cancel Stripe subscription (continuing): {str(e)}")
+
+        if target_user.keycloak_id:
+            await auth_service.delete_user(target_user.keycloak_id)
+            logger.info(f"[{request_id}] Deleted user {target_user.keycloak_id} from Keycloak")
+
+        target_keycloak_id = target_user.keycloak_id
+        await db.delete(target_user)
+        await db.commit()
+        logger.info(f"[{request_id}] Deleted user {user_id} from database")
+
+        try:
+            await user_service_cached.invalidate_user_cache(user_id, target_keycloak_id)
+        except Exception as e:
+            logger.warning(f"[{request_id}] Failed to invalidate caches (continuing): {str(e)}")
+
+        return {"message": "User deleted successfully", "statusCode": 200}
+
+    except HTTPException:
+        await db.rollback()
+        raise
+    except Exception as e:
+        await db.rollback()
+        logger.error(f"[{request_id}] Unexpected error during user deletion: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to delete user. Please try again or contact support.",
+        )
+
+
 @router.put("/users/{user_id}/role", response_model=UserResponse)
 async def update_user_role(
     role_data: UpdateUserRoleRequest,
@@ -275,6 +361,53 @@ async def update_user_role(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to update user role",
         )
+
+
+@router.patch("/users/{user_id}/organization", response_model=UserResponse)
+async def assign_user_organization(
+    payload: AssignUserOrganizationRequest,
+    user_id: UUID = Path(..., title="The ID of the user to update"),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+    _: bool = Depends(require_role("super_admin")),
+):
+    """
+    Assign or unassign a user's organization (Super Admin only).
+
+    Body: {"organization_id": "<uuid>" | null}
+    """
+    request_id = str(uuid.uuid4())
+
+    target_result = await db.execute(select(User).where(User.id == user_id))
+    target_user = target_result.scalar_one_or_none()
+    if target_user is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"User with ID {user_id} not found",
+        )
+
+    if payload.organization_id is not None:
+        org_result = await db.execute(select(Organization).where(Organization.id == payload.organization_id))
+        if org_result.scalar_one_or_none() is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Organization {payload.organization_id} not found",
+            )
+
+    target_user.organization_id = payload.organization_id
+    await db.commit()
+    await db.refresh(target_user)
+
+    try:
+        await user_service_cached.invalidate_user_cache(user_id, target_user.keycloak_id)
+    except Exception as e:
+        logger.warning(f"[{request_id}] Failed to invalidate caches after org change: {e}")
+
+    logger.info(
+        f"[{request_id}] Super admin {current_user.username} set user {target_user.username} "
+        f"organization_id to {payload.organization_id}"
+    )
+    return target_user
 
 
 # Add cache management endpoints for admin users

--- a/app/main.py
+++ b/app/main.py
@@ -27,6 +27,7 @@ from app.controllers.facebook_stream_controller import router as facebook_stream
 from app.controllers.health_controller import router as health_router
 from app.controllers.internal_controller import router as internal_router
 from app.controllers.notification_controller import router as notification_router
+from app.controllers.org_admin_controller import router as org_admin_router
 from app.controllers.payment_controller import router as payment_router
 from app.controllers.rtmp_controller import router as stream_router
 from app.controllers.twitch_controller import router as twitch_router
@@ -290,3 +291,4 @@ app.include_router(facebook_stream_router)
 app.include_router(payment_router)
 app.include_router(notification_router)
 app.include_router(admin_router)
+app.include_router(org_admin_router)

--- a/app/main.py
+++ b/app/main.py
@@ -38,6 +38,7 @@ from app.models import (  # noqa: F401
     connection_model,
     fcm_token_model,
     notification_models,
+    organization_models,
     payment_models,
     stream_session_models,
     user_models,

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -3,6 +3,7 @@ from app.models.bbb_models import BbbMeeting
 from app.models.channel.channels_model import Channel
 from app.models.connection_model import Connection
 from app.models.event.event_models import Event
+from app.models.organization_models import Organization, OrganizationEmailDomain
 from app.models.stream_models import RtmpEndpoint
 from app.models.stream_session_models import StreamSession
 from app.models.user_models import User
@@ -16,5 +17,7 @@ __all__ = [
     "RtmpEndpoint",
     "BbbMeeting",
     "Connection",
+    "Organization",
+    "OrganizationEmailDomain",
     "StreamSession",
 ]

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -3,7 +3,11 @@ from app.models.bbb_models import BbbMeeting
 from app.models.channel.channels_model import Channel
 from app.models.connection_model import Connection
 from app.models.event.event_models import Event
-from app.models.organization_models import Organization, OrganizationEmailDomain
+from app.models.organization_models import (
+    Organization,
+    OrganizationEmailDomain,
+    OrganizationInvite,
+)
 from app.models.stream_models import RtmpEndpoint
 from app.models.stream_session_models import StreamSession
 from app.models.user_models import User
@@ -19,5 +23,6 @@ __all__ = [
     "Connection",
     "Organization",
     "OrganizationEmailDomain",
+    "OrganizationInvite",
     "StreamSession",
 ]

--- a/app/models/admin_schemas.py
+++ b/app/models/admin_schemas.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict
 
@@ -90,9 +91,22 @@ class RevenueStats(BaseModel):
     latest_transactions: list[RecentTransaction]
 
 
+class OrganizationStats(BaseModel):
+    id: UUID | None
+    name: str
+    user_count: int
+    active_users: int
+    events_total: int
+    bbb_meetings_total: int
+    streams_30d: int
+    active_subscriptions: int
+    revenue_30d_usd: float
+
+
 class AnalyticsOverview(BaseModel):
     generated_at: datetime
     users: UsersStats
     events: EventsStats
     streaming: StreamingStats
     revenue: RevenueStats
+    organizations: list[OrganizationStats]

--- a/app/models/organization_models.py
+++ b/app/models/organization_models.py
@@ -87,6 +87,5 @@ class OrganizationInvite(Base):
 
     def __repr__(self) -> str:
         return (
-            f"<OrganizationInvite(code={self.code!r}, org_id={self.organization_id!r}, "
-            f"revoked={self.revoked_at is not None})>"
+            f"<OrganizationInvite(code={self.code!r}, org_id={self.organization_id!r}, revoked={self.revoked_at is not None})>"
         )

--- a/app/models/organization_models.py
+++ b/app/models/organization_models.py
@@ -27,13 +27,9 @@ class Organization(Base):
     name: Mapped[str] = mapped_column(String, unique=True, nullable=False)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.now, nullable=False)
-    updated_at: Mapped[datetime] = mapped_column(
-        DateTime, default=datetime.now, onupdate=datetime.now, nullable=False
-    )
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.now, onupdate=datetime.now, nullable=False)
 
-    users: Mapped[list[User]] = relationship(
-        "User", back_populates="organization", passive_deletes=True
-    )
+    users: Mapped[list[User]] = relationship("User", back_populates="organization", passive_deletes=True)
     email_domains: Mapped[list[OrganizationEmailDomain]] = relationship(
         "OrganizationEmailDomain",
         back_populates="organization",

--- a/app/models/organization_models.py
+++ b/app/models/organization_models.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.config.database.session import Base
+
+if TYPE_CHECKING:
+    from app.models.user_models import User
+
+
+class Organization(Base):
+    __tablename__ = "organizations"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        index=True,
+        nullable=False,
+    )
+    name: Mapped[str] = mapped_column(String, unique=True, nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.now, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.now, onupdate=datetime.now, nullable=False
+    )
+
+    users: Mapped[list[User]] = relationship(
+        "User", back_populates="organization", passive_deletes=True
+    )
+    email_domains: Mapped[list[OrganizationEmailDomain]] = relationship(
+        "OrganizationEmailDomain",
+        back_populates="organization",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+    )
+
+    def __repr__(self) -> str:
+        return f"<Organization(id={self.id!r}, name={self.name!r})>"
+
+
+class OrganizationEmailDomain(Base):
+    __tablename__ = "organization_email_domains"
+
+    domain: Mapped[str] = mapped_column(String, primary_key=True)
+    organization_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("organizations.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    organization: Mapped[Organization] = relationship("Organization", back_populates="email_domains")
+
+    def __repr__(self) -> str:
+        return f"<OrganizationEmailDomain(domain={self.domain!r}, org_id={self.organization_id!r})>"

--- a/app/models/organization_models.py
+++ b/app/models/organization_models.py
@@ -51,8 +51,42 @@ class OrganizationEmailDomain(Base):
         nullable=False,
         index=True,
     )
+    verified_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    verification_token: Mapped[str | None] = mapped_column(String, nullable=True)
+    verification_started_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
     organization: Mapped[Organization] = relationship("Organization", back_populates="email_domains")
 
     def __repr__(self) -> str:
-        return f"<OrganizationEmailDomain(domain={self.domain!r}, org_id={self.organization_id!r})>"
+        return (
+            f"<OrganizationEmailDomain(domain={self.domain!r}, "
+            f"org_id={self.organization_id!r}, verified={self.verified_at is not None})>"
+        )
+
+
+class OrganizationInvite(Base):
+    __tablename__ = "organization_invites"
+
+    code: Mapped[str] = mapped_column(String, primary_key=True)
+    organization_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("organizations.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    created_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.now, nullable=False)
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    expires_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+
+    organization: Mapped[Organization] = relationship("Organization")
+
+    def __repr__(self) -> str:
+        return (
+            f"<OrganizationInvite(code={self.code!r}, org_id={self.organization_id!r}, "
+            f"revoked={self.revoked_at is not None})>"
+        )

--- a/app/models/organization_schemas.py
+++ b/app/models/organization_schemas.py
@@ -64,11 +64,23 @@ class OrganizationUpdate(BaseModel):
         return _normalize_domains(v)
 
 
+class EmailDomainDetail(BaseModel):
+    domain: str
+    verified: bool
+    verified_at: datetime | None = None
+    verification_record_name: str | None = None
+    verification_record_value: str | None = None
+
+
 class OrganizationResponse(BaseModel):
     id: UUID
     name: str
     is_active: bool
     email_domains: list[str]
+    # Per-domain verification view. Populated by `_serialize_org` in the
+    # controllers; the legacy `email_domains` field above is kept as a simple
+    # string list for the super-admin dashboard.
+    email_domain_details: list[EmailDomainDetail] = []
     created_at: datetime
     updated_at: datetime
 
@@ -77,3 +89,81 @@ class OrganizationResponse(BaseModel):
 
 class AssignUserOrganizationRequest(BaseModel):
     organization_id: UUID | None
+
+
+def _normalize_single_domain(v: str) -> str:
+    d = (v or "").strip().lower().lstrip("@")
+    if not d:
+        raise ValueError("email_domain cannot be empty")
+    if not _DOMAIN_RE.match(d):
+        raise ValueError(f"Invalid email domain: {v!r}")
+    return d
+
+
+class CreateMyOrgRequest(BaseModel):
+    """Self-serve org creation by a non-super-admin user."""
+
+    name: str = Field(..., min_length=1, max_length=255)
+    email_domain: str = Field(..., min_length=1, max_length=253)
+
+    @field_validator("name")
+    def _strip_name(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("name cannot be empty")
+        return v
+
+    @field_validator("email_domain")
+    def _normalize_domain(cls, v: str) -> str:
+        return _normalize_single_domain(v)
+
+
+class JoinOrgRequest(BaseModel):
+    code: str = Field(..., min_length=1, max_length=64)
+
+    @field_validator("code")
+    def _strip_code(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("code cannot be empty")
+        return v
+
+
+class AddDomainRequest(BaseModel):
+    """Org admin adding an additional email domain to their existing org."""
+
+    domain: str = Field(..., min_length=1, max_length=253)
+
+    @field_validator("domain")
+    def _normalize_domain(cls, v: str) -> str:
+        return _normalize_single_domain(v)
+
+
+class DomainVerificationStatus(BaseModel):
+    """One row in the email_domains list with verification metadata."""
+
+    domain: str
+    verified: bool
+    verification_token: str | None
+    verification_record_name: str | None
+    verification_record_value: str | None
+
+
+class CreateMyOrgResponse(BaseModel):
+    organization: OrganizationResponse
+    verification: DomainVerificationStatus
+
+
+class OrganizationInviteResponse(BaseModel):
+    code: str
+    organization_id: UUID
+    created_at: datetime
+    revoked_at: datetime | None
+    expires_at: datetime | None
+    join_path: str  # e.g. "/join/org/<code>"
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class JoinOrgResponse(BaseModel):
+    organization: OrganizationResponse

--- a/app/models/organization_schemas.py
+++ b/app/models/organization_schemas.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+_DOMAIN_RE = re.compile(r"^(?=.{1,253}$)([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$")
+
+
+def _normalize_domains(value: list[str] | None) -> list[str]:
+    if not value:
+        return []
+    seen: set[str] = set()
+    out: list[str] = []
+    for raw in value:
+        d = (raw or "").strip().lower().lstrip("@")
+        if not d:
+            continue
+        if not _DOMAIN_RE.match(d):
+            raise ValueError(f"Invalid email domain: {raw!r}")
+        if d in seen:
+            continue
+        seen.add(d)
+        out.append(d)
+    return out
+
+
+class OrganizationCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=255)
+    email_domains: list[str] = Field(default_factory=list)
+
+    @field_validator("name")
+    def _strip_name(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("name cannot be empty")
+        return v
+
+    @field_validator("email_domains")
+    def _normalize(cls, v: list[str]) -> list[str]:
+        return _normalize_domains(v)
+
+
+class OrganizationUpdate(BaseModel):
+    name: str | None = Field(None, min_length=1, max_length=255)
+    email_domains: list[str] | None = None
+    is_active: bool | None = None
+
+    @field_validator("name")
+    def _strip_name(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        v = v.strip()
+        if not v:
+            raise ValueError("name cannot be empty")
+        return v
+
+    @field_validator("email_domains")
+    def _normalize(cls, v: list[str] | None) -> list[str] | None:
+        if v is None:
+            return None
+        return _normalize_domains(v)
+
+
+class OrganizationResponse(BaseModel):
+    id: UUID
+    name: str
+    is_active: bool
+    email_domains: list[str]
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AssignUserOrganizationRequest(BaseModel):
+    organization_id: UUID | None

--- a/app/models/user_models.py
+++ b/app/models/user_models.py
@@ -43,6 +43,7 @@ class User(Base):
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     unlimited_access: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     has_used_free_trial: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    has_completed_onboarding: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     default_resolution: Mapped[str | None] = mapped_column(String, nullable=True)
     organization_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),

--- a/app/models/user_models.py
+++ b/app/models/user_models.py
@@ -52,9 +52,7 @@ class User(Base):
     )
 
     # Relationships
-    organization: Mapped["Organization | None"] = relationship(
-        "Organization", back_populates="users", lazy="selectin"
-    )
+    organization: Mapped[Organization | None] = relationship("Organization", back_populates="users", lazy="selectin")
     rtmp_endpoints: Mapped[list[RtmpEndpoint]] = relationship(
         "RtmpEndpoint", back_populates="user", cascade="all, delete-orphan"
     )

--- a/app/models/user_models.py
+++ b/app/models/user_models.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Boolean, DateTime, String
+from sqlalchemy import Boolean, DateTime, ForeignKey, String
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from app.models.connection_model import Connection
     from app.models.fcm_token_model import FCMToken
     from app.models.notification_models import Notification, NotificationPreference
+    from app.models.organization_models import Organization
     from app.models.payment_models import Subscription
 
 
@@ -43,8 +44,17 @@ class User(Base):
     unlimited_access: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     has_used_free_trial: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     default_resolution: Mapped[str | None] = mapped_column(String, nullable=True)
+    organization_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("organizations.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
 
     # Relationships
+    organization: Mapped["Organization | None"] = relationship(
+        "Organization", back_populates="users", lazy="selectin"
+    )
     rtmp_endpoints: Mapped[list[RtmpEndpoint]] = relationship(
         "RtmpEndpoint", back_populates="user", cascade="all, delete-orphan"
     )

--- a/app/models/user_schemas.py
+++ b/app/models/user_schemas.py
@@ -22,6 +22,7 @@ class UserResponse(UserBase):
     roles: str
     created_at: datetime | None = None
     is_active: bool
+    organization_id: UUID | None = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/app/models/user_schemas.py
+++ b/app/models/user_schemas.py
@@ -23,6 +23,7 @@ class UserResponse(UserBase):
     created_at: datetime | None = None
     is_active: bool
     organization_id: UUID | None = None
+    has_completed_onboarding: bool = False
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/app/services/admin_analytics_service.py
+++ b/app/services/admin_analytics_service.py
@@ -9,6 +9,7 @@ from app.config.logger_config import get_logger
 from app.models.bbb_models import BbbMeeting
 from app.models.connection_model import Connection
 from app.models.event.event_models import Event, EventStatus
+from app.models.organization_models import Organization
 from app.models.payment_models import Subscription, SubscriptionStatus, Transaction
 from app.models.stream_session_models import StreamSession, StreamSessionStatus
 from app.models.user_models import User
@@ -244,6 +245,137 @@ class AdminAnalyticsService:
             ],
         }
 
+    @staticmethod
+    async def _organizations_stats(db: AsyncSession) -> list[dict]:
+        """
+        Per-organization rollup. One row per existing Organization plus a
+        synthetic "Unassigned" row (id=None) aggregating users with
+        ``organization_id IS NULL``. Each metric is one GROUP BY query,
+        stitched in Python — matches the existing one-query-per-metric style.
+        """
+        now = utcnow()
+        d30 = now - timedelta(days=30)
+
+        orgs_rows = (await db.execute(select(Organization.id, Organization.name))).all()
+        rows: dict[object, dict] = {}
+        for org_id, name in orgs_rows:
+            rows[org_id] = {
+                "id": org_id,
+                "name": name,
+                "user_count": 0,
+                "active_users": 0,
+                "events_total": 0,
+                "bbb_meetings_total": 0,
+                "streams_30d": 0,
+                "active_subscriptions": 0,
+                "revenue_30d_usd": 0.0,
+            }
+        rows[None] = {
+            "id": None,
+            "name": "Unassigned",
+            "user_count": 0,
+            "active_users": 0,
+            "events_total": 0,
+            "bbb_meetings_total": 0,
+            "streams_30d": 0,
+            "active_subscriptions": 0,
+            "revenue_30d_usd": 0.0,
+        }
+
+        def _bucket(org_id):
+            # Orgs may have been deleted between metric queries — fall back to Unassigned.
+            return rows.get(org_id, rows[None])
+
+        user_counts = (
+            await db.execute(select(User.organization_id, func.count(User.id)).group_by(User.organization_id))
+        ).all()
+        for org_id, count in user_counts:
+            _bucket(org_id)["user_count"] = count
+
+        active_user_counts = (
+            await db.execute(
+                select(User.organization_id, func.count(User.id))
+                .where(User.is_active.is_(True))
+                .group_by(User.organization_id)
+            )
+        ).all()
+        for org_id, count in active_user_counts:
+            _bucket(org_id)["active_users"] = count
+
+        event_counts = (
+            await db.execute(
+                select(User.organization_id, func.count(Event.id))
+                .join(User, Event.creator_id == User.id)
+                .group_by(User.organization_id)
+            )
+        ).all()
+        for org_id, count in event_counts:
+            _bucket(org_id)["events_total"] = count
+
+        bbb_counts = (
+            await db.execute(
+                select(User.organization_id, func.count(BbbMeeting.id))
+                .join(User, BbbMeeting.user_id == User.id)
+                .group_by(User.organization_id)
+            )
+        ).all()
+        for org_id, count in bbb_counts:
+            _bucket(org_id)["bbb_meetings_total"] = count
+
+        stream_counts = (
+            await db.execute(
+                select(User.organization_id, func.count(StreamSession.id))
+                .join(User, StreamSession.user_id == User.id)
+                .where(StreamSession.started_at >= d30)
+                .group_by(User.organization_id)
+            )
+        ).all()
+        for org_id, count in stream_counts:
+            _bucket(org_id)["streams_30d"] = count
+
+        sub_counts = (
+            await db.execute(
+                select(User.organization_id, func.count(Subscription.id))
+                .join(User, Subscription.user_id == User.id)
+                .where(
+                    Subscription.status.in_(
+                        [SubscriptionStatus.ACTIVE.value, SubscriptionStatus.TRIALING.value]
+                    )
+                )
+                .group_by(User.organization_id)
+            )
+        ).all()
+        for org_id, count in sub_counts:
+            _bucket(org_id)["active_subscriptions"] = count
+
+        revenue_rows = (
+            await db.execute(
+                select(User.organization_id, func.coalesce(func.sum(Transaction.amount), 0.0))
+                .join(Subscription, Transaction.subscription_id == Subscription.id)
+                .join(User, Subscription.user_id == User.id)
+                .where(
+                    Transaction.created_at >= d30,
+                    Transaction.transaction_type == "payment",
+                    Transaction.status.in_(["succeeded", "paid", "complete"]),
+                )
+                .group_by(User.organization_id)
+            )
+        ).all()
+        for org_id, amount in revenue_rows:
+            _bucket(org_id)["revenue_30d_usd"] = float(amount or 0.0)
+
+        # Stable display order: real orgs A→Z, then Unassigned last.
+        out = sorted(
+            (r for k, r in rows.items() if k is not None),
+            key=lambda r: r["name"].lower(),
+        )
+        unassigned = rows[None]
+        # Only include the Unassigned row if it has any signal — keeps a clean dashboard
+        # while still surfacing the bucket the moment there are unassigned users.
+        if any(unassigned[k] for k in ("user_count", "events_total", "bbb_meetings_total", "streams_30d")):
+            out.append(unassigned)
+        return out
+
     @classmethod
     async def get_overview(cls, db: AsyncSession) -> dict:
         return {
@@ -252,4 +384,5 @@ class AdminAnalyticsService:
             "events": await cls._events_stats(db),
             "streaming": await cls._streaming_stats(db),
             "revenue": await cls._revenue_stats(db),
+            "organizations": await cls._organizations_stats(db),
         }

--- a/app/services/admin_analytics_service.py
+++ b/app/services/admin_analytics_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
+from uuid import UUID
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -17,25 +18,65 @@ from app.utils.datetime_utils import utcnow
 
 logger = get_logger("AdminAnalyticsService")
 
+# Sentinel value for the "no organization" bucket in filter inputs.
+UNASSIGNED = "unassigned"
+
+# Type alias for an organization filter value:
+#   None        -> no filter (platform-wide)
+#   "unassigned" -> users with NULL organization_id
+#   UUID        -> filter to that organization
+OrgFilter = UUID | str | None
+
+
+def _user_ids_subquery(org_filter: OrgFilter):
+    """
+    Return a scalar subquery of User.id values matching the given filter,
+    or None when no filtering is requested. Callers use it with
+    ``SomeTable.<user_fk>.in_(subq)`` to scope a query to a single org.
+    """
+    if org_filter is None:
+        return None
+    base = select(User.id)
+    if org_filter == UNASSIGNED:
+        base = base.where(User.organization_id.is_(None))
+    else:
+        base = base.where(User.organization_id == org_filter)
+    return base.scalar_subquery()
+
+
+def _apply_user_org_filter(stmt, org_filter: OrgFilter):
+    """Apply an organization scope directly to a User-rooted query."""
+    if org_filter is None:
+        return stmt
+    if org_filter == UNASSIGNED:
+        return stmt.where(User.organization_id.is_(None))
+    return stmt.where(User.organization_id == org_filter)
+
 
 class AdminAnalyticsService:
     """Compute platform-wide snapshot metrics for the admin dashboard."""
 
     @staticmethod
-    async def _users_stats(db: AsyncSession) -> dict:
+    async def _users_stats(db: AsyncSession, org_filter: OrgFilter = None) -> dict:
         now = utcnow()
         d7 = now - timedelta(days=7)
         d30 = now - timedelta(days=30)
 
-        total = (await db.execute(select(func.count(User.id)))).scalar_one()
-        active = (await db.execute(select(func.count(User.id)).where(User.is_active.is_(True)))).scalar_one()
-        new_7d = (await db.execute(select(func.count(User.id)).where(User.created_at >= d7))).scalar_one()
-        new_30d = (await db.execute(select(func.count(User.id)).where(User.created_at >= d30))).scalar_one()
+        total = (await db.execute(_apply_user_org_filter(select(func.count(User.id)), org_filter))).scalar_one()
+        active = (
+            await db.execute(_apply_user_org_filter(select(func.count(User.id)).where(User.is_active.is_(True)), org_filter))
+        ).scalar_one()
+        new_7d = (
+            await db.execute(_apply_user_org_filter(select(func.count(User.id)).where(User.created_at >= d7), org_filter))
+        ).scalar_one()
+        new_30d = (
+            await db.execute(_apply_user_org_filter(select(func.count(User.id)).where(User.created_at >= d30), org_filter))
+        ).scalar_one()
 
         # Role breakdown: roles is comma-separated, so compute in Python over a
         # lightweight projection. Population is small (admins/moderators); avoid
         # complex SQL string-splitting that doesn't port cleanly across dialects.
-        rows = (await db.execute(select(User.roles))).scalars().all()
+        rows = (await db.execute(_apply_user_org_filter(select(User.roles), org_filter))).scalars().all()
         by_role: dict[str, int] = {}
         for raw in rows:
             if not raw:
@@ -44,7 +85,7 @@ class AdminAnalyticsService:
                 if r:
                     by_role[r] = by_role.get(r, 0) + 1
 
-        latest_q = select(User).order_by(User.created_at.desc()).limit(5)
+        latest_q = _apply_user_org_filter(select(User).order_by(User.created_at.desc()).limit(5), org_filter)
         latest = (await db.execute(latest_q)).scalars().all()
 
         return {
@@ -68,24 +109,36 @@ class AdminAnalyticsService:
         }
 
     @staticmethod
-    async def _events_stats(db: AsyncSession) -> dict:
+    async def _events_stats(db: AsyncSession, org_filter: OrgFilter = None) -> dict:
         now = utcnow()
         d7 = now - timedelta(days=7)
         d30 = now - timedelta(days=30)
 
-        total = (await db.execute(select(func.count(Event.id)))).scalar_one()
-        created_7d = (await db.execute(select(func.count(Event.id)).where(Event.created_at >= d7))).scalar_one()
-        created_30d = (await db.execute(select(func.count(Event.id)).where(Event.created_at >= d30))).scalar_one()
+        user_subq = _user_ids_subquery(org_filter)
 
-        status_rows = (await db.execute(select(Event.status, func.count(Event.id)).group_by(Event.status))).all()
+        def _scope_event(stmt):
+            return stmt.where(Event.creator_id.in_(user_subq)) if user_subq is not None else stmt
+
+        def _scope_bbb(stmt):
+            return stmt.where(BbbMeeting.user_id.in_(user_subq)) if user_subq is not None else stmt
+
+        total = (await db.execute(_scope_event(select(func.count(Event.id))))).scalar_one()
+        created_7d = (await db.execute(_scope_event(select(func.count(Event.id)).where(Event.created_at >= d7)))).scalar_one()
+        created_30d = (
+            await db.execute(_scope_event(select(func.count(Event.id)).where(Event.created_at >= d30)))
+        ).scalar_one()
+
+        status_rows = (await db.execute(_scope_event(select(Event.status, func.count(Event.id))).group_by(Event.status))).all()
         by_status: dict[str, int] = {s.value if hasattr(s, "value") else str(s): c for s, c in status_rows}
         for s in EventStatus:
             by_status.setdefault(s.value, 0)
 
-        bbb_total = (await db.execute(select(func.count(BbbMeeting.id)))).scalar_one()
-        bbb_30d = (await db.execute(select(func.count(BbbMeeting.id)).where(BbbMeeting.created_at >= d30))).scalar_one()
+        bbb_total = (await db.execute(_scope_bbb(select(func.count(BbbMeeting.id))))).scalar_one()
+        bbb_30d = (
+            await db.execute(_scope_bbb(select(func.count(BbbMeeting.id)).where(BbbMeeting.created_at >= d30)))
+        ).scalar_one()
 
-        latest_q = select(Event).order_by(Event.created_at.desc()).limit(5)
+        latest_q = _scope_event(select(Event).order_by(Event.created_at.desc()).limit(5))
         latest = (await db.execute(latest_q)).scalars().all()
 
         return {
@@ -109,43 +162,53 @@ class AdminAnalyticsService:
         }
 
     @staticmethod
-    async def _streaming_stats(db: AsyncSession) -> dict:
+    async def _streaming_stats(db: AsyncSession, org_filter: OrgFilter = None) -> dict:
         now = utcnow()
         d1 = now - timedelta(days=1)
         d30 = now - timedelta(days=30)
 
-        total = (await db.execute(select(func.count(StreamSession.id)))).scalar_one()
+        user_subq = _user_ids_subquery(org_filter)
+
+        def _scope_session(stmt):
+            return stmt.where(StreamSession.user_id.in_(user_subq)) if user_subq is not None else stmt
+
+        def _scope_connection(stmt):
+            return stmt.where(Connection.user_id.in_(user_subq)) if user_subq is not None else stmt
+
+        total = (await db.execute(_scope_session(select(func.count(StreamSession.id))))).scalar_one()
         sessions_24h = (
-            await db.execute(select(func.count(StreamSession.id)).where(StreamSession.started_at >= d1))
+            await db.execute(_scope_session(select(func.count(StreamSession.id)).where(StreamSession.started_at >= d1)))
         ).scalar_one()
         sessions_30d = (
-            await db.execute(select(func.count(StreamSession.id)).where(StreamSession.started_at >= d30))
+            await db.execute(_scope_session(select(func.count(StreamSession.id)).where(StreamSession.started_at >= d30)))
         ).scalar_one()
         active_now = (
             await db.execute(
-                select(func.count(StreamSession.id)).where(StreamSession.status == StreamSessionStatus.ACTIVE.value)
+                _scope_session(
+                    select(func.count(StreamSession.id)).where(StreamSession.status == StreamSessionStatus.ACTIVE.value)
+                )
             )
         ).scalar_one()
 
         platform_rows = (
             await db.execute(
-                select(StreamSession.platform, func.count(StreamSession.id))
-                .where(StreamSession.started_at >= d30)
-                .group_by(StreamSession.platform)
+                _scope_session(
+                    select(StreamSession.platform, func.count(StreamSession.id)).where(StreamSession.started_at >= d30)
+                ).group_by(StreamSession.platform)
             )
         ).all()
         by_platform: dict[str, int] = {(p or "unknown"): c for p, c in platform_rows}
 
         conn_rows = (
             await db.execute(
-                select(Connection.provider, func.count(Connection.id))
-                .where(Connection.revoked_at.is_(None))
-                .group_by(Connection.provider)
+                _scope_connection(
+                    select(Connection.provider, func.count(Connection.id)).where(Connection.revoked_at.is_(None))
+                ).group_by(Connection.provider)
             )
         ).all()
         connections_by_provider: dict[str, int] = {p: c for p, c in conn_rows}
 
-        latest_q = select(StreamSession).order_by(StreamSession.started_at.desc()).limit(5)
+        latest_q = _scope_session(select(StreamSession).order_by(StreamSession.started_at.desc()).limit(5))
         latest = (await db.execute(latest_q)).scalars().all()
 
         return {
@@ -170,29 +233,47 @@ class AdminAnalyticsService:
         }
 
     @staticmethod
-    async def _revenue_stats(db: AsyncSession) -> dict:
+    async def _revenue_stats(db: AsyncSession, org_filter: OrgFilter = None) -> dict:
         now = utcnow()
         d7 = now - timedelta(days=7)
         d30 = now - timedelta(days=30)
 
+        user_subq = _user_ids_subquery(org_filter)
+        # Subscriptions owned by users matching the filter; reused for Transaction.subscription_id.
+        sub_subq = (
+            select(Subscription.id).where(Subscription.user_id.in_(user_subq)).scalar_subquery()
+            if user_subq is not None
+            else None
+        )
+
+        def _scope_sub(stmt):
+            return stmt.where(Subscription.user_id.in_(user_subq)) if user_subq is not None else stmt
+
+        def _scope_tx(stmt):
+            return stmt.where(Transaction.subscription_id.in_(sub_subq)) if sub_subq is not None else stmt
+
         plan_rows = (
-            await db.execute(select(Subscription.plan, func.count(Subscription.id)).group_by(Subscription.plan))
+            await db.execute(_scope_sub(select(Subscription.plan, func.count(Subscription.id))).group_by(Subscription.plan))
         ).all()
         subs_by_plan: dict[str, int] = {p: c for p, c in plan_rows}
 
         status_rows = (
-            await db.execute(select(Subscription.status, func.count(Subscription.id)).group_by(Subscription.status))
+            await db.execute(
+                _scope_sub(select(Subscription.status, func.count(Subscription.id))).group_by(Subscription.status)
+            )
         ).all()
         subs_by_status: dict[str, int] = {s: c for s, c in status_rows}
 
         active_subs = (
             await db.execute(
-                select(func.count(Subscription.id)).where(
-                    Subscription.status.in_(
-                        [
-                            SubscriptionStatus.ACTIVE.value,
-                            SubscriptionStatus.TRIALING.value,
-                        ]
+                _scope_sub(
+                    select(func.count(Subscription.id)).where(
+                        Subscription.status.in_(
+                            [
+                                SubscriptionStatus.ACTIVE.value,
+                                SubscriptionStatus.TRIALING.value,
+                            ]
+                        )
                     )
                 )
             )
@@ -201,28 +282,32 @@ class AdminAnalyticsService:
         # Revenue: sum of successful 'payment' transactions in last 30 days
         revenue_30d = (
             await db.execute(
-                select(func.coalesce(func.sum(Transaction.amount), 0.0)).where(
-                    Transaction.created_at >= d30,
-                    Transaction.transaction_type == "payment",
-                    Transaction.status.in_(["succeeded", "paid", "complete"]),
+                _scope_tx(
+                    select(func.coalesce(func.sum(Transaction.amount), 0.0)).where(
+                        Transaction.created_at >= d30,
+                        Transaction.transaction_type == "payment",
+                        Transaction.status.in_(["succeeded", "paid", "complete"]),
+                    )
                 )
             )
         ).scalar_one()
 
         transactions_30d_count = (
-            await db.execute(select(func.count(Transaction.id)).where(Transaction.created_at >= d30))
+            await db.execute(_scope_tx(select(func.count(Transaction.id)).where(Transaction.created_at >= d30)))
         ).scalar_one()
 
         failed_payments_7d = (
             await db.execute(
-                select(func.count(Transaction.id)).where(
-                    Transaction.created_at >= d7,
-                    Transaction.transaction_type.in_(["failed"]),
+                _scope_tx(
+                    select(func.count(Transaction.id)).where(
+                        Transaction.created_at >= d7,
+                        Transaction.transaction_type.in_(["failed"]),
+                    )
                 )
             )
         ).scalar_one()
 
-        latest_q = select(Transaction).order_by(Transaction.created_at.desc()).limit(5)
+        latest_q = _scope_tx(select(Transaction).order_by(Transaction.created_at.desc()).limit(5))
         latest = (await db.execute(latest_q)).scalars().all()
 
         return {
@@ -337,11 +422,7 @@ class AdminAnalyticsService:
             await db.execute(
                 select(User.organization_id, func.count(Subscription.id))
                 .join(User, Subscription.user_id == User.id)
-                .where(
-                    Subscription.status.in_(
-                        [SubscriptionStatus.ACTIVE.value, SubscriptionStatus.TRIALING.value]
-                    )
-                )
+                .where(Subscription.status.in_([SubscriptionStatus.ACTIVE.value, SubscriptionStatus.TRIALING.value]))
                 .group_by(User.organization_id)
             )
         ).all()
@@ -377,12 +458,21 @@ class AdminAnalyticsService:
         return out
 
     @classmethod
-    async def get_overview(cls, db: AsyncSession) -> dict:
+    async def get_overview(cls, db: AsyncSession, org_filter: OrgFilter = None) -> dict:
+        """
+        Build the admin dashboard payload.
+
+        ``org_filter`` scopes the per-tab metrics (users, events, streaming,
+        revenue) to a single organization (UUID), to the Unassigned bucket
+        (``"unassigned"``), or to the whole platform (``None``). The
+        ``organizations`` rollup is always platform-wide — it IS the
+        breakdown view, so it would be meaningless to filter it.
+        """
         return {
             "generated_at": utcnow(),
-            "users": await cls._users_stats(db),
-            "events": await cls._events_stats(db),
-            "streaming": await cls._streaming_stats(db),
-            "revenue": await cls._revenue_stats(db),
+            "users": await cls._users_stats(db, org_filter),
+            "events": await cls._events_stats(db, org_filter),
+            "streaming": await cls._streaming_stats(db, org_filter),
+            "revenue": await cls._revenue_stats(db, org_filter),
             "organizations": await cls._organizations_stats(db),
         }

--- a/app/services/cached/user_service_cached.py
+++ b/app/services/cached/user_service_cached.py
@@ -43,11 +43,19 @@ class UserServiceCached:
         return list(res.scalars().all())  # Convert to list for serialization
 
     async def invalidate_user_cache(self, user_id: UUID, keycloak_id: str | None = None):
-        """Invalidate all caches for a specific user"""
-        await cache.delete_pattern(f"user_profile:*{user_id}*")
-        await cache.delete_pattern(f"user_roles:*{user_id}*")
+        """Invalidate all caches for a specific user.
+
+        ``cached_db`` builds keys as ``{prefix}:{func_name}:{md5(args)}`` —
+        the user_id / keycloak_id never appears literally in the key, so a
+        substring pattern like ``user_profile:*<user_id>*`` matches nothing.
+        Dropping the whole prefix is the only correct option. With a small
+        user count this is fine; even at scale the 15-min TTL bounds the
+        cost of re-warming.
+        """
+        await cache.delete_pattern("user_profile:*")
+        await cache.delete_pattern("user_roles:*")
         if keycloak_id:
-            await cache.delete_pattern(f"user_keycloak:*{keycloak_id}*")
+            await cache.delete_pattern("user_keycloak:*")
         await cache.delete_pattern("users_list:*")
         logger.info(f"Invalidated user caches for {user_id}")
 

--- a/app/services/org_verification_service.py
+++ b/app/services/org_verification_service.py
@@ -1,0 +1,59 @@
+"""DNS TXT record verification for self-serve organization domain claims.
+
+Self-serve org creation hands the admin a token and asks them to publish a
+TXT record at ``_bluescale-verify.<domain>`` with the value
+``bluescale-verify=<token>``. This module is the one place that talks to DNS.
+"""
+
+from __future__ import annotations
+
+import dns.asyncresolver
+import dns.exception
+
+from app.config.logger_config import get_logger
+
+logger = get_logger("OrgVerificationService")
+
+VERIFICATION_RECORD_PREFIX = "_bluescale-verify"
+VERIFICATION_VALUE_PREFIX = "bluescale-verify="
+_DNS_TIMEOUT_SECONDS = 5.0
+
+
+def verification_record_name(domain: str) -> str:
+    """The fully-qualified DNS name the org admin must publish a TXT record at."""
+    return f"{VERIFICATION_RECORD_PREFIX}.{domain}"
+
+
+def verification_record_value(token: str) -> str:
+    """The exact TXT record value the org admin must publish."""
+    return f"{VERIFICATION_VALUE_PREFIX}{token}"
+
+
+async def verify_domain_record(domain: str, expected_token: str) -> bool:
+    """
+    Resolve ``_bluescale-verify.<domain>`` TXT records and look for an exact
+    ``bluescale-verify=<expected_token>`` match.
+
+    Returns True on match, False on missing record / NXDOMAIN / timeout — any
+    transient or expected failure surfaces as "not verified yet" to the caller.
+    """
+    record_name = verification_record_name(domain)
+    expected_value = verification_record_value(expected_token)
+    try:
+        answer = await dns.asyncresolver.resolve(
+            record_name, "TXT", lifetime=_DNS_TIMEOUT_SECONDS
+        )
+    except dns.exception.DNSException as e:
+        logger.info(f"DNS verification miss for {record_name}: {e.__class__.__name__}")
+        return False
+
+    for rdata in answer:
+        # dnspython splits TXT into chunks; rejoin before comparing.
+        chunks = getattr(rdata, "strings", None) or []
+        joined = b"".join(chunks).decode("utf-8", errors="replace")
+        if joined == expected_value:
+            logger.info(f"DNS verification SUCCESS for {record_name}")
+            return True
+
+    logger.info(f"DNS verification record present at {record_name} but token did not match")
+    return False

--- a/app/services/org_verification_service.py
+++ b/app/services/org_verification_service.py
@@ -40,9 +40,7 @@ async def verify_domain_record(domain: str, expected_token: str) -> bool:
     record_name = verification_record_name(domain)
     expected_value = verification_record_value(expected_token)
     try:
-        answer = await dns.asyncresolver.resolve(
-            record_name, "TXT", lifetime=_DNS_TIMEOUT_SECONDS
-        )
+        answer = await dns.asyncresolver.resolve(record_name, "TXT", lifetime=_DNS_TIMEOUT_SECONDS)
     except dns.exception.DNSException as e:
         logger.info(f"DNS verification miss for {record_name}: {e.__class__.__name__}")
         return False


### PR DESCRIPTION
## Summary

Activates the `admin` role and adds a self-serve onboarding flow on top of the Organizations slice. Users can either create an organization (with DNS TXT verification) or join one via a reusable invite link.

## What's new

**Self-serve onboarding** — `/api/me/organization/*`
- `POST /create` — atomic Keycloak admin grant + DB commit + JWT cookie refresh in the response
- `POST /join` — join via invite code
- `POST /skip-onboarding` — explicit opt-out, lands in Unassigned

**Org-scoped admin endpoints**
- `GET /api/me/organization`, `GET /overview`, `GET /users`, `PATCH /users/{id}/role` (moderator ↔ admin only)

**Domain management** (org admin)
- `POST /domains`, `POST /domains/{domain}/verify`, `DELETE /domains/{domain}`
- DNS TXT check via `dnspython`, on-demand only
- Auto-match in `process_user_info` now requires `verified_at IS NOT NULL`

**Invite codes**
- `GET /invite` (current active code), `POST /invite/rotate`

**Super-admin**
- `GET /admin/analytics/overview?organization_id=<uuid|unassigned>` — scope per-tab metrics
- Domains added via super-admin org creation are server-trusted (immediate `verified_at`)

## Bug fix

`invalidate_user_cache` was building delete patterns like `user_profile:*<user_id>*`, but the cache key uses an MD5 hash so the user_id never appeared literally. Stale `/api/me` reads for up to 15 min after every profile/role/org change. Replaced with prefix-wide deletes.

## Schema changes

Migration `d3e4f5a6b7c8`:
- `users.has_completed_onboarding BOOL DEFAULT FALSE` — backfilled to TRUE for existing users
- `organization_email_domains` adds `verified_at`, `verification_token`, `verification_started_at` — existing rows backfilled with `verified_at = NOW()`
- New `organization_invites` table